### PR TITLE
add drop-in support

### DIFF
--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -17,11 +17,24 @@ module Systemd
       %i( device target )
     end
 
-    def unit_path(unit)
-      ::File.join('/etc/systemd/system', "#{unit.name}.#{unit.unit_type}")
+    def local_conf_root
+      '/etc/systemd/system'
     end
 
-    module_function :ini_config, :unit_types, :stub_units, :unit_path
+    def drop_in_root(unit)
+      ::File.join(local_conf_root, "#{unit.override}.d")
+    end
+
+    def unit_path(unit)
+      if unit.drop_in
+        ::File.join(drop_in_root(unit), "#{unit.name}.conf")
+      else
+        ::File.join(local_conf_root, "#{unit.name}.#{unit.unit_type}")
+      end
+    end
+
+    module_function :ini_config, :unit_types, :drop_in_root,
+                    :unit_path, :local_conf_root, :stub_units
   end
 end
 

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -22,7 +22,7 @@ module Systemd
     end
 
     def drop_in_root(unit)
-      ::File.join(local_conf_root, "#{unit.override}.d")
+      ::File.join(local_conf_root, "#{unit.override}.#{unit.unit_type}.d")
     end
 
     def unit_path(unit)

--- a/libraries/provider_systemd_unit.rb
+++ b/libraries/provider_systemd_unit.rb
@@ -17,13 +17,6 @@ class Chef::Provider
     action :create do
       unit_path = Systemd::Helpers.unit_path(new_resource)
 
-      if new_resource.drop_in && new_resource.override.nil?
-        fail(
-          Chef::Exceptions::ValidationFailed,
-          'Required argument override is missing!'
-        )
-      end
-
       directory Systemd::Helpers.drop_in_root(new_resource) do
         only_if { new_resource.drop_in }
       end

--- a/libraries/provider_systemd_unit.rb
+++ b/libraries/provider_systemd_unit.rb
@@ -17,6 +17,13 @@ class Chef::Provider
     action :create do
       unit_path = Systemd::Helpers.unit_path(new_resource)
 
+      if new_resource.drop_in && new_resource.override.nil?
+        fail(
+          Chef::Exceptions::ValidationFailed,
+          'Required argument override is missing!'
+        )
+      end
+
       directory Systemd::Helpers.drop_in_root(new_resource) do
         only_if { new_resource.drop_in }
       end

--- a/libraries/provider_systemd_unit.rb
+++ b/libraries/provider_systemd_unit.rb
@@ -17,6 +17,10 @@ class Chef::Provider
     action :create do
       unit_path = Systemd::Helpers.unit_path(new_resource)
 
+      directory Systemd::Helpers.drop_in_root(new_resource) do
+        only_if { new_resource.drop_in }
+      end
+
       execute 'reload-sytemd' do
         command 'systemctl daemon-reload'
         action :nothing

--- a/libraries/resource_systemd_unit.rb
+++ b/libraries/resource_systemd_unit.rb
@@ -44,8 +44,9 @@ class Chef::Resource
     end
 
     # rubocop: disable CyclomaticComplexity
-    # rubocop: disable AbcSize
+    # rubocop: disable PerceivedComplexity
     # rubocop: disable MethodLength
+    # rubocop: disable AbcSize
     def to_hash
       conf = {}
 
@@ -58,13 +59,11 @@ class Chef::Resource
         conf[section] = []
 
         # handle overrides if resource is a drop-in unit
-        if drop_in
-          overrides.each do |over_ride|
-            if section_options.include?(over_ride) || over_ride == "Alias"
-              conf[section] << "#{over_ride}="
-            end
+        overrides.each do |over_ride|
+          if section_options.include?(over_ride) || over_ride == 'Alias'
+            conf[section] << "#{over_ride}="
           end
-        end
+        end if drop_in
 
         # handle Alias special case
         if section == 'install' && !aliases.empty?
@@ -72,7 +71,7 @@ class Chef::Resource
         end
 
         # convert resource attributes to KV-pair values in the hash
-        Systemd.const_get(section.capitalize)::OPTIONS.each do |option|
+        section_options.each do |option|
           attr = send(option.underscore.to_sym)
           conf[section] << "#{option.camelize}=#{attr}" unless attr.nil?
         end
@@ -80,8 +79,9 @@ class Chef::Resource
 
       conf
     end
-    # rubocop: enable MethodLength
     # rubocop: enable AbcSize
+    # rubocop: enable MethodLength
+    # rubocop: enable PerceivedComplexity
     # rubocop: enable CyclomaticComplexity
 
     alias_method :to_h, :to_hash

--- a/libraries/resource_systemd_unit.rb
+++ b/libraries/resource_systemd_unit.rb
@@ -64,7 +64,7 @@ class Chef::Resource
       return [] unless drop_in
 
       section_overrides = overrides.select do |o|
-        opts.include?(o) || (section == 'install' && o == 'Alias')
+        opts.include?(o) || (section == :install && o == 'Alias')
       end
 
       section_overrides.map do |over_ride|

--- a/libraries/resource_systemd_unit.rb
+++ b/libraries/resource_systemd_unit.rb
@@ -1,3 +1,4 @@
+require 'chef/mixin/params_validate'
 require 'chef/resource/lwrp_base'
 require_relative 'systemd_install'
 require_relative 'systemd_unit'
@@ -5,6 +6,8 @@ require_relative 'helpers'
 
 class Chef::Resource
   class SystemdUnit < Chef::Resource::LWRPBase
+    include Chef::Mixin::ParamsValidate
+
     self.resource_name = :systemd_unit
     provides :systemd_unit
 
@@ -13,9 +16,24 @@ class Chef::Resource
 
     attribute :unit_type, kind_of: Symbol, equal_to: Systemd::Helpers.unit_types, default: :service, required: true # rubocop: disable LineLength
     attribute :aliases, kind_of: Array, default: []
-    attribute :drop_in, kind_of: [TrueClass, FalseClass], default: false
-    attribute :override, kind_of: String, default: nil
     attribute :overrides, kind_of: Array, default: []
+
+    def drop_in(arg = nil)
+      set_or_return(
+        :drop_in, arg,
+        kind_of: [TrueClass, FalseClass],
+        default: false
+      )
+    end
+
+    def override(arg = nil)
+      set_or_return(
+        :override, arg,
+        kind_of: String,
+        default: nil,
+        required: drop_in
+      )
+    end
 
     # define class method for defining resource
     # attributes from the resource module options

--- a/libraries/resource_systemd_unit.rb
+++ b/libraries/resource_systemd_unit.rb
@@ -73,7 +73,7 @@ class Chef::Resource
     end
 
     def alias_config(section)
-      return [] unless section == 'install' && !aliases.empty?
+      return [] unless section == :install && !aliases.empty?
       ["Alias=#{aliases.map { |a| "#{a}.#{unit_type}" }.join(' ')}"]
     end
 

--- a/libraries/resource_systemd_unit.rb
+++ b/libraries/resource_systemd_unit.rb
@@ -55,12 +55,12 @@ class Chef::Resource
     def section_values(section)
       opts = Systemd.const_get(section.capitalize)::OPTIONS
 
-      [].concat handle_overrides(section, opts)
-        .concat handle_alias(section)
-        .concat handle_options(opts)
+      [].concat overrides_config(section, opts)
+        .concat alias_config(section)
+        .concat options_config(opts)
     end
 
-    def handle_overrides(section, opts)
+    def overrides_config(section, opts)
       return [] unless drop_in
 
       section_overrides = overrides.select do |o|
@@ -72,12 +72,12 @@ class Chef::Resource
       end
     end
 
-    def handle_alias(section)
+    def alias_config(section)
       return [] unless section == 'install' && !aliases.empty?
       ["Alias=#{aliases.join(' ')}"]
     end
 
-    def handle_options(opts)
+    def options_config(opts)
       opts.reject { |o| send(o.underscore.to_sym).nil? }.map do |opt|
         "#{opt.camelize}=#{send(opt.underscore.to_sym)}"
       end

--- a/libraries/resource_systemd_unit.rb
+++ b/libraries/resource_systemd_unit.rb
@@ -74,7 +74,7 @@ class Chef::Resource
 
     def alias_config(section)
       return [] unless section == 'install' && !aliases.empty?
-      ["Alias=#{aliases.join(' ')}"]
+      ["Alias=#{aliases.map { |a| "#{a}.#{unit_type}" }.join(' ')}"]
     end
 
     def options_config(opts)

--- a/test/fixtures/cookbooks/setup/recipes/default.rb
+++ b/test/fixtures/cookbooks/setup/recipes/default.rb
@@ -20,7 +20,7 @@ systemd_service 'my-override' do
     Alias
     Description
   )
-  aliases %w( ssh.service openssh.service )
+  aliases %w( ssh openssh )
   cpu_quota '10%'
 end
 

--- a/test/fixtures/cookbooks/setup/recipes/default.rb
+++ b/test/fixtures/cookbooks/setup/recipes/default.rb
@@ -15,7 +15,7 @@ end
 systemd_service 'my-override' do
   description 'Test Override'
   drop_in true
-  override 'sshd.service'
+  override 'sshd'
   overrides %w(
     Alias
     Description

--- a/test/fixtures/cookbooks/setup/recipes/default.rb
+++ b/test/fixtures/cookbooks/setup/recipes/default.rb
@@ -2,7 +2,7 @@ systemd_service 'test-unit' do
   description 'Test Service'
   documentation 'man:true(1)'
   install do
-    aliases %w( testing-unit.service testd.service )
+    aliases %w( testing-unit testd )
     wanted_by 'multi-user.target'
   end
   service do

--- a/test/fixtures/cookbooks/setup/recipes/default.rb
+++ b/test/fixtures/cookbooks/setup/recipes/default.rb
@@ -13,10 +13,12 @@ systemd_service 'test-unit' do
 end
 
 systemd_service 'my-override' do
+  description 'Test Override'
   drop_in true
   override 'sshd.service'
   overrides %w(
     Alias
+    Description
   )
   aliases %w( ssh.service openssh.service )
   cpu_quota '10%'

--- a/test/fixtures/cookbooks/setup/recipes/default.rb
+++ b/test/fixtures/cookbooks/setup/recipes/default.rb
@@ -12,6 +12,16 @@ systemd_service 'test-unit' do
   end
 end
 
+systemd_service 'my-override' do
+  drop_in true
+  override 'sshd.service'
+  overrides %w(
+    Alias
+  )
+  aliases %w( ssh.service openssh.service )
+  cpu_quota '10%'
+end
+
 systemd_socket 'sshd' do
   description 'SSH Socket for Per-Connection Servers'
   install do


### PR DESCRIPTION
adds drop-in support for units, and cleans up that messy to_hash method on the unit resource.

/cc @stevendanna @ranjib 
