### PR TITLE
documentation!

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,6 @@ Recommended reading:
 
 ## Recipes
 
-
 ## Resources
 
 ### Foreword
@@ -79,47 +78,78 @@ Also supports: [unit][common_unit], [install][common_install]
 
 ### systemd_mount
 
+Unit which describes a file system mount point controlled by systemd.
+[Documentation][mount]
+
 |Attribute|Description|Default|
 |---------|-----------|-------|
+||||
 
 Also supports: [unit][common_unit], [install][common_install]
 
 ### systemd_path
+[Docuemtnation][path]
+
+Unit which describes information about a path monitored by systemd for
+path-based activities.
 
 |Attribute|Description|Default|
 |---------|-----------|-------|
+||||
 
 Also supports: [unit][common_unit], [install][common_install]
 
 ### systemd_service
 
+Unit which describes information about a process controlled and supervised by systemd.
+[Documentation][service]
+
 |Attribute|Description|Default|
 |---------|-----------|-------|
+||||
 
 Also supports: [unit][common_unit], [install][common_install]
 
 ### systemd_slice
 
+Unit which describes a "slice" of the system; useful for managing resources
+for of a group of processes.
+[Documentation][slice]
+
 |Attribute|Description|Default|
 |---------|-----------|-------|
+||||
 
 Also supports: [unit][common_unit], [install][common_install]
 
 ### systemd_socket
 
+Unit which describes an IPC, network socket, or file-system FIFO controlled
+and supervised by systemd for socket-based service activation.
+[Documentation][socket]
+
 |Attribute|Description|Default|
 |---------|-----------|-------|
+||||
 
 Also supports: [unit][common_unit], [install][common_install]
 
 ### systemd_swap
 
+Unit which describes a swap device or file for memory paging.
+[Documentation][swap]
+
 |Attribute|Description|Default|
 |---------|-----------|-------|
+||||
 
 Also supports: [unit][common_unit], [install][common_install]
 
 ### systemd_target
+
+Unit which describes a systemd target, used for grouping units and
+synchronization points during system start-up.
+[Documentation][target]
 
 This unit has no specific options.
 
@@ -127,8 +157,13 @@ Also supports: [unit][common_unit], [install][common_install]
 
 ### systemd_timer
 
+Unit which describes a timer managed by systemd, for timer-based unit
+activation (typically a service of the same name).
+[Documentation][timer]
+
 |Attribute|Description|Default|
 |---------|-----------|-------|
+||||
 
 Also supports: [unit][common_unit], [install][common_install]
 
@@ -138,27 +173,33 @@ Also supports: [unit][common_unit], [install][common_install]
 
 |Attribute|Description|Default|
 |---------|-----------|-------|
+||||
 
 ### install
 
 |Attribute|Description|Default|
 |---------|-----------|-------|
+||||
 
 ### kill
 
 |Attribute|Description|Default|
 |---------|-----------|-------|
+||||
 
 ### exec
 
 |Attribute|Description|Default|
 |---------|-----------|-------|
+||||
 
 ### resource-control
 
 |Attribute|Description|Default|
 |---------|-----------|-------|
+||||
 
+---
 [automount]: http://www.freedesktop.org/software/systemd/man/systemd.automount.html
 [blog]: http://0pointer.de/blog/projects/systemd-for-admins-1.html
 [chef]: https://chef.io

--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ Also supports: [unit][common_unit], [install][common_install]
 [blog]: http://0pointer.de/blog/projects/systemd-for-admins-1.html
 [chef]: https://chef.io
 [common_install]: #install
-[common_unit]: #unit 
+[common_unit]: #unit
 [docs]: http://www.freedesktop.org/wiki/Software/systemd/
 [ini]: https://en.wikipedia.org/wiki/INI_file
 [install]: http://www.freedesktop.org/software/systemd/man/systemd.unit.html#%5BInstall%5D%20Section%20Options

--- a/README.md
+++ b/README.md
@@ -62,9 +62,9 @@ Unit which describes a file system automount point controlled by systemd.
 
 |Attribute|Description|Default|
 |---------|-----------|-------|
-|where||nil|
-|directory_mode||nil|
-|timeout_idle_sec||nil|
+|where|absolute path of automount directory|nil|
+|directory_mode|access mode when creating automount directory|nil|
+|timeout_idle_sec|idleness timeout before attempting to unmount|nil|
 
 Also supports: [unit][common_unit], [install][common_install]
 
@@ -163,11 +163,19 @@ Also supports: [unit][common_unit], [install][common_install]
 [chef]: https://chef.io
 [common_install]: #install
 [common_unit]: #unit
+[device]: http://www.freedesktop.org/software/systemd/man/systemd.device.html
 [docs]: http://www.freedesktop.org/wiki/Software/systemd/
 [ini]: https://en.wikipedia.org/wiki/INI_file
 [install]: http://www.freedesktop.org/software/systemd/man/systemd.unit.html#%5BInstall%5D%20Section%20Options
+[mount]: http://www.freedesktop.org/software/systemd/man/systemd.mount.html
+[path]: http://www.freedesktop.org/software/systemd/man/systemd.path.html
 [rhel]: https://access.redhat.com/articles/754933
+[service]: http://www.freedesktop.org/software/systemd/man/systemd.service.html
+[slice]: http://www.freedesktop.org/software/systemd/man/systemd.slice.html
+[socket]: http://www.freedesktop.org/software/systemd/man/systemd.socket.html
+[swap]: http://www.freedesktop.org/software/systemd/man/systemd.swap.html
+[target]: http://www.freedesktop.org/software/systemd/man/systemd.target.html
+[timer]: http://www.freedesktop.org/software/systemd/man/systemd.timer.html
 [travis]: https://travis-ci.org/nathwill/chef-systemd
 [unit]: http://www.freedesktop.org/software/systemd/man/systemd.unit.html#%5BUnit%5D%20Section%20Options
 [units]: http://www.freedesktop.org/software/systemd/man/systemd.unit.html
-

--- a/README.md
+++ b/README.md
@@ -73,45 +73,63 @@ Also supports: [unit][common_unit], [install][common_install]
 |Attribute|Description|Default|
 |---------|-----------|-------|
 
+Also supports: [unit][common_unit], [install][common_install]
+
 ### systemd_mount
 
 |Attribute|Description|Default|
 |---------|-----------|-------|
+
+Also supports: [unit][common_unit], [install][common_install]
 
 ### systemd_path
 
 |Attribute|Description|Default|
 |---------|-----------|-------|
 
+Also supports: [unit][common_unit], [install][common_install]
+
 ### systemd_service
 
 |Attribute|Description|Default|
 |---------|-----------|-------|
+
+Also supports: [unit][common_unit], [install][common_install]
 
 ### systemd_slice
 
 |Attribute|Description|Default|
 |---------|-----------|-------|
 
+Also supports: [unit][common_unit], [install][common_install]
+
 ### systemd_socket
 
 |Attribute|Description|Default|
 |---------|-----------|-------|
+
+Also supports: [unit][common_unit], [install][common_install]
 
 ### systemd_swap
 
 |Attribute|Description|Default|
 |---------|-----------|-------|
 
+Also supports: [unit][common_unit], [install][common_install]
+
 ### systemd_target
 
 |Attribute|Description|Default|
 |---------|-----------|-------|
 
+Also supports: [unit][common_unit], [install][common_install]
+
 ### systemd_timer
 
 |Attribute|Description|Default|
 |---------|-----------|-------|
+
+Also supports: [unit][common_unit], [install][common_install]
 
 ## Common Attributes
 
@@ -139,7 +157,6 @@ Also supports: [unit][common_unit], [install][common_install]
 
 |Attribute|Description|Default|
 |---------|-----------|-------|
-
 
 [automount]: http://www.freedesktop.org/software/systemd/man/systemd.automount.html
 [blog]: http://0pointer.de/blog/projects/systemd-for-admins-1.html

--- a/README.md
+++ b/README.md
@@ -58,9 +58,10 @@ There are also 3 special groups of unit options that are common between several
 types of units: exec, kill, and resource-control, which handle common options
 re: execution environment configuration (e.g. "WorkingDirectory"), process
 killing procedure configuration (e.g. "KillSignal"), and resource control
-settings (e.g. "MemoryLimit"). Resources which support these attributes along
-with their type-specific attributes are explicitly noted in the resource
-documentation below, and linked to the documentation for those attributes.
+settings (e.g. "MemoryLimit"). Cookbook resources which support these common
+attributes along with their type-specific attributes are explicitly noted in
+the resource documentation below, and linked to the documentation for those
+attributes.
 
 Hey! That sounds pretty easy, right?
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Recommended reading:
 
 ### systemd::hostnamed
 
-### systemd::journal-gatewayd
+### systemd::journal_gatewayd
 
 ### systemd::journald
 
@@ -92,7 +92,9 @@ Unit which describes a device as exposed in the sysfs/udev device tree.
 
 This resource has no specific options.
 
-Also supports: [unit][common_unit], [install][common_install]
+Also supports:
+- [unit][common_unit]
+- [install][common_install]
 
 ### systemd_mount
 
@@ -101,9 +103,21 @@ Unit which describes a file system mount point controlled by systemd.
 
 |Attribute|Description|Default|
 |---------|-----------|-------|
-||||
+|directory_mode|||
+|kill_mode|||
+|kill_signal|||
+|options|||
+|send_sighup|||
+|send_sigkill|||
+|sloppy_options|||
+|timeout_sec|||
+|type|||
+|what|||
+|where|||
 
-Also supports: [unit][common_unit], [install][common_install]
+Also supports:
+- [unit][common_unit]
+- [install][common_install]
 
 ### systemd_path
 
@@ -114,9 +128,18 @@ path-based activities.
 
 |Attribute|Description|Default|
 |---------|-----------|-------|
-||||
+|directory_mode|||
+|directory_not_empty|||
+|make_directory|||
+|path_changed|||
+|path_exists|||
+|path_exists_glob|||
+|path_modified|||
+|unit|||
 
-Also supports: [unit][common_unit], [install][common_install]
+Also supports:
+- [unit][common_unit]
+- [install][common_install]
 
 ### systemd_service
 
@@ -125,9 +148,42 @@ Unit which describes information about a process controlled and supervised by sy
 
 |Attribute|Description|Default|
 |---------|-----------|-------|
-||||
+|bus_name|||
+|bus_policy|||
+|exec_reload|||
+|exec_start|||
+|exec_start_post|||
+|exec_start_pre|||
+|exec_stop|||
+|exec_stop_post|||
+|failure_action|||
+|file_descriptor_store_max|||
+|guess_main_pid|||
+|non_blocking|||
+|notify_access|||
+|permissions_start_only|||
+|pid_file|||
+|reboot_argument|||
+|remain_after_exit|||
+|restart|||
+|restart_force_exit_status|||
+|restart_prevent_exit_status|||
+|restart_sec|||
+|root_directory_start_only|||
+|sockets|||
+|start_limit_action|||
+|start_limit_burst|||
+|start_limit_interval|||
+|success_exit_status|||
+|timeout_sec|||
+|timeout_start_sec|||
+|timeout_stop_sec|||
+|type|||
+|watchdog_sec|||
 
-Also supports: [unit][common_unit], [install][common_install]
+Also supports:
+- [unit][common_unit]
+- [install][common_install]
 
 ### systemd_slice
 
@@ -135,11 +191,12 @@ Unit which describes a "slice" of the system; useful for managing resources
 for of a group of processes.
 [Documentation][slice]
 
-|Attribute|Description|Default|
-|---------|-----------|-------|
-||||
+This resource has no specific options.
 
-Also supports: [unit][common_unit], [install][common_install]
+Also supports:
+- [unit][common_unit]
+- [install][common_install]
+- [resource-control][resource_control]
 
 ### systemd_socket
 
@@ -149,9 +206,60 @@ and supervised by systemd for socket-based service activation.
 
 |Attribute|Description|Default|
 |---------|-----------|-------|
-||||
+|accept|||
+|backlog|||
+|bind_i_pv6_only|||
+|bind_to_device|||
+|broadcast|||
+|defer_accept_sec|||
+|directory_mode|||
+|exec_start_post|||
+|exec_start_pre|||
+|exec_stop_post|||
+|exec_stop_pre|||
+|free_bind|||
+|iptos|||
+|ipttl|||
+|keep_alive|||
+|keep_alive_interval_sec|||
+|keep_alive_probes|||
+|keep_alive_time_sec|||
+|listen_datagram|||
+|listen_fifo|||
+|listen_message_queue|||
+|listen_netlink|||
+|listen_sequential_packet|||
+|listen_special|||
+|listen_stream|||
+|mark|||
+|max_connections|||
+|message_queue_max_messages|||
+|message_queue_message_size|||
+|no_delay|||
+|pass_credentials|||
+|pass_security|||
+|pipe_size|||
+|priority|||
+|receive_buffer|||
+|remove_on_stop|||
+|reuse_port|||
+|se_linux_context_from_net|||
+|send_buffer|||
+|service|||
+|smack_label|||
+|smack_label_ip_in|||
+|smack_label_ip_out|||
+|socket_group|||
+|socket_mode|||
+|socket_user|||
+|symlinks|||
+|tcp_congestion|||
+|timeout_sec|||
+|transparent|||
 
-Also supports: [unit][common_unit], [install][common_install]
+Also supports:
+- [unit][common_unit]
+- [install][common_install]
 
 ### systemd_swap
 
@@ -160,9 +268,14 @@ Unit which describes a swap device or file for memory paging.
 
 |Attribute|Description|Default|
 |---------|-----------|-------|
-||||
+|options|||
+|priority|||
+|timeout_sec|||
+|what|||
 
-Also supports: [unit][common_unit], [install][common_install]
+Also supports:
+- [unit][common_unit]
+- [install][common_install]
 
 ### systemd_target
 
@@ -172,7 +285,9 @@ synchronization points during system start-up.
 
 This unit has no specific options.
 
-Also supports: [unit][common_unit], [install][common_install]
+Also supports:
+- [unit][common_unit]
+- [install][common_install]
 
 ### systemd_timer
 
@@ -182,9 +297,20 @@ activation (typically a service of the same name).
 
 |Attribute|Description|Default|
 |---------|-----------|-------|
-||||
+|accuracy_sec|||
+|on_active_sec|||
+|on_boot_sec|||
+|on_calendar|||
+|on_startup_sec|||
+|on_unit_active_sec|||
+|on_unit_inactive_sec|||
+|persistent|||
+|unit|||
+|wake_system|||
 
-Also supports: [unit][common_unit], [install][common_install]
+Also supports:
+- [unit][common_unit]
+- [install][common_install]
 
 ## Common Attributes
 
@@ -192,31 +318,186 @@ Also supports: [unit][common_unit], [install][common_install]
 
 |Attribute|Description|Default|
 |---------|-----------|-------|
-||||
+|after|||
+|allow_isolate|||
+|assert_ac_power|||
+|assert_architecture|||
+|assert_capability|||
+|assert_directory_not_empty|||
+|assert_file_is_executable|||
+|assert_file_not_empty|||
+|assert_first_boot|||
+|assert_host|||
+|assert_kernel_command_line|||
+|assert_needs_update|||
+|assert_path_exists|||
+|assert_path_exists_glob|||
+|assert_path_is_directory|||
+|assert_path_is_mount_point|||
+|assert_path_is_read_write|||
+|assert_path_is_symbolic_link|||
+|assert_security|||
+|assert_virtualization|||
+|before|||
+|binds_to|||
+|condition_ac_power|||
+|condition_architecture|||
+|condition_capability|||
+|condition_directory_not_empty|||
+|condition_file_is_executable|||
+|condition_file_not_empty|||
+|condition_first_boot|||
+|condition_host|||
+|condition_kernel_command_line|||
+|condition_needs_update|||
+|condition_path_exists|||
+|condition_path_exists_glob|||
+|condition_path_is_directory|||
+|condition_path_is_mount_point|||
+|condition_path_is_read_write|||
+|condition_path_is_symbolic_link|||
+|condition_security|||
+|condition_virtualization|||
+|conflicts|||
+|default_dependencies|||
+|description|||
+|documentation|||
+|ignore_on_isolate|||
+|ignore_on_snapshot|||
+|job_timeout_action|||
+|job_timeout_reboot_argument|||
+|job_timeout_sec|||
+|joins_namespace_of|||
+|on_failure|||
+|on_failure_job_mode|||
+|part_of|||
+|propagates_reload_to|||
+|refuse_manual_start|||
+|refuse_manual_stop|||
+|reload_propagated_from|||
+|requires|||
+|requires_mounts_for|||
+|requires_overridable|||
+|requisite|||
+|requisite_overridable|||
+|source_path|||
+|stop_when_unneeded|||
+|wants|||
 
 ### install
 
 |Attribute|Description|Default|
 |---------|-----------|-------|
-||||
+|aliases||||
+|also|||
+|default_instance|||
+|required_by|||
+|wanted_by|||
 
 ### kill
 
 |Attribute|Description|Default|
 |---------|-----------|-------|
-||||
+|kill_mode|||
+|kill_signal|||
+|send_sighup|||
+|send_sigkill|||
 
 ### exec
 
 |Attribute|Description|Default|
 |---------|-----------|-------|
-||||
+|app_armor_profile|||
+|capabilities|||
+|capability_bounding_set|||
+|cpu_affinity|||
+|cpu_scheduling_policy|||
+|cpu_scheduling_priority|||
+|cpu_scheduling_reset_on_fork|||
+|environment|||
+|environment_file|||
+|group|||
+|ignore_sigpipe|||
+|inaccessible_directories|||
+|io_scheduling_class|||
+|io_scheduling_priority|||
+|limit_as|||
+|limit_core|||
+|limit_cpu|||
+|limit_data|||
+|limit_fsize|||
+|limit_locks|||
+|limit_memlock|||
+|limit_msgqueue|||
+|limit_nice|||
+|limit_nofile|||
+|limit_nproc|||
+|limit_rss|||
+|limit_rtprio|||
+|limit_rttime|||
+|limit_sigpending|||
+|limit_stack|||
+|mount_flags|||
+|nice|||
+|no_new_privileges|||
+|oom_score_adjust|||
+|pam_name|||
+|personality|||
+|private_devices|||
+|private_network|||
+|private_tmp|||
+|protect_home|||
+|protect_system|||
+|read_only_directories|||
+|read_write_directories|||
+|restrict_address_families|||
+|root_directory|||
+|runtime_directory|||
+|runtime_directory_mode|||
+|se_linux_context|||
+|secure_bits|||
+|smack_process_label|||
+|standard_error|||
+|standard_input|||
+|standard_output|||
+|supplementary_groups|||
+|syslog_facility|||
+|syslog_identifier|||
+|syslog_level|||
+|syslog_level_prefix|||
+|system_call_architectures|||
+|system_call_error_number|||
+|system_call_filter|||
+|timer_slack_n_sec|||
+|tty_path|||
+|tty_reset|||
+|ttyv_hangup|||
+|ttyvt_disallocate|||
+|u_mask|||
+|user|||
+|utmp_identifier|||
+|working_directory|||
 
 ### resource-control
 
 |Attribute|Description|Default|
 |---------|-----------|-------|
-||||
+|block_io_accounting|||
+|block_io_device_weight|||
+|block_io_read_bandwidth|||
+|block_io_weight|||
+|block_io_write_bandwidth|||
+|cpu_accounting|||
+|cpu_quota|||
+|cpu_shares|||
+|delegate|||
+|device_allow|||
+|device_policy|||
+|memory_accounting|||
+|memory_limit|||
+|slice|||
+|startup_block_io_weight|||
+|startup_cpu_shares|||
 
 ---
 [automount]: http://www.freedesktop.org/software/systemd/man/systemd.automount.html
@@ -231,6 +512,7 @@ Also supports: [unit][common_unit], [install][common_install]
 [mount]: http://www.freedesktop.org/software/systemd/man/systemd.mount.html
 [path]: http://www.freedesktop.org/software/systemd/man/systemd.path.html
 [rhel]: https://access.redhat.com/articles/754933
+[resource_control]: 
 [service]: http://www.freedesktop.org/software/systemd/man/systemd.service.html
 [slice]: http://www.freedesktop.org/software/systemd/man/systemd.slice.html
 [socket]: http://www.freedesktop.org/software/systemd/man/systemd.socket.html

--- a/README.md
+++ b/README.md
@@ -4,18 +4,8 @@ A resource-drive [Chef][chef] cookbook for [systemd][docs]. Currently under
 construction; see issues for list of ways to contribute :)
 
 Cookbook builds on a core systemd_unit resource in order to provide resources
-for the following unit types:
-
-- automount
-- device
-- mount
-- path
-- service
-- slice
-- socket
-- swap
-- target
-- timer
+for the following unit types: automount, device, mount, path, service, slice,
+socket, swap, target, timer.
 
 Recommended reading:
 - This README!

--- a/README.md
+++ b/README.md
@@ -70,8 +70,10 @@ Also supports: [unit][common_unit], [install][common_install]
 
 ### systemd_device
 
-|Attribute|Description|Default|
-|---------|-----------|-------|
+Unit which describes a device as exposed in the sysfs/udev device tree.
+[Documentation][device]
+
+This resource has no specific options.
 
 Also supports: [unit][common_unit], [install][common_install]
 
@@ -119,8 +121,7 @@ Also supports: [unit][common_unit], [install][common_install]
 
 ### systemd_target
 
-|Attribute|Description|Default|
-|---------|-----------|-------|
+This unit has no specific options.
 
 Also supports: [unit][common_unit], [install][common_install]
 

--- a/README.md
+++ b/README.md
@@ -67,32 +67,83 @@ Hey! That sounds pretty easy, right?
 
 ### systemd_automount
 
+|Attribute|Description|Default|
+|---------|-----------|-------|
+|where||nil|
+|directory_mode||nil|
+|timeout_idle_sec||nil|
+
 ### systemd_device
+
+|Attribute|Description|Default|
+|---------|-----------|-------|
 
 ### systemd_mount
 
+|Attribute|Description|Default|
+|---------|-----------|-------|
+
 ### systemd_path
+
+|Attribute|Description|Default|
+|---------|-----------|-------|
 
 ### systemd_service
 
+|Attribute|Description|Default|
+|---------|-----------|-------|
+
 ### systemd_slice
+
+|Attribute|Description|Default|
+|---------|-----------|-------|
 
 ### systemd_socket
 
+|Attribute|Description|Default|
+|---------|-----------|-------|
+
 ### systemd_swap
+
+|Attribute|Description|Default|
+|---------|-----------|-------|
 
 ### systemd_target
 
+|Attribute|Description|Default|
+|---------|-----------|-------|
+
 ### systemd_timer
+
+|Attribute|Description|Default|
+|---------|-----------|-------|
 
 ## Common Attributes
 
+### unit
+
+|Attribute|Description|Default|
+|---------|-----------|-------|
+
+### install
+
+|Attribute|Description|Default|
+|---------|-----------|-------|
+
 ### kill
+
+|Attribute|Description|Default|
+|---------|-----------|-------|
 
 ### exec
 
+|Attribute|Description|Default|
+|---------|-----------|-------|
+
 ### resource-control
 
+|Attribute|Description|Default|
+|---------|-----------|-------|
 
 [blog]: http://0pointer.de/blog/projects/systemd-for-admins-1.html
 [chef]: https://chef.io

--- a/README.md
+++ b/README.md
@@ -17,6 +17,24 @@ Recommended reading:
 
 ## Recipes
 
+### systemd::hostnamed
+
+### systemd::journal-gatewayd
+
+### systemd::journald
+
+### systemd::logind
+
+### systemd::machined
+
+### systemd::networkd
+
+### systemd::resolved
+
+### systemd::timedated
+
+### systemd::timesyncd
+
 ## Resources
 
 ### Foreword

--- a/README.md
+++ b/README.md
@@ -79,11 +79,13 @@ Unit which describes a file system automount point controlled by systemd.
 
 |Attribute|Description|Default|
 |---------|-----------|-------|
-|where|absolute path of automount directory|nil|
-|directory_mode|access mode when creating automount directory|nil|
-|timeout_idle_sec|idleness timeout before attempting to unmount|nil|
+|where|see docs|nil|
+|directory_mode|see docs|nil|
+|timeout_idle_sec|see docs|nil|
 
-Also supports: [unit][common_unit], [install][common_install]
+Also supports:
+- [unit](#unit)
+- [install](#install)
 
 ### systemd_device
 
@@ -93,8 +95,8 @@ Unit which describes a device as exposed in the sysfs/udev device tree.
 This resource has no specific options.
 
 Also supports:
-- [unit][common_unit]
-- [install][common_install]
+- [unit](#unit)
+- [install](#install)
 
 ### systemd_mount
 
@@ -103,21 +105,24 @@ Unit which describes a file system mount point controlled by systemd.
 
 |Attribute|Description|Default|
 |---------|-----------|-------|
-|directory_mode|||
-|kill_mode|||
-|kill_signal|||
-|options|||
-|send_sighup|||
-|send_sigkill|||
-|sloppy_options|||
-|timeout_sec|||
-|type|||
-|what|||
-|where|||
+|directory_mode|see docs|nil|
+|kill_mode|see docs|nil|
+|kill_signal|see docs|nil|
+|options|see docs|nil|
+|send_sighup|see docs|nil|
+|send_sigkill|see docs|nil|
+|sloppy_options|see docs|nil|
+|timeout_sec|see docs|nil|
+|type|see docs|nil|
+|what|see docs|nil|
+|where|see docs|nil|
 
 Also supports:
-- [unit][common_unit]
-- [install][common_install]
+- [unit](#unit)
+- [install](#install)
+- [exec](#exec)
+- [kill](#kill)
+- [resource-control](#resource-control)
 
 ### systemd_path
 
@@ -128,18 +133,18 @@ path-based activities.
 
 |Attribute|Description|Default|
 |---------|-----------|-------|
-|directory_mode|||
-|directory_not_empty|||
-|make_directory|||
-|path_changed|||
-|path_exists|||
-|path_exists_glob|||
-|path_modified|||
-|unit|||
+|directory_mode|see docs|nil|
+|directory_not_empty|see docs|nil|
+|make_directory|see docs|nil|
+|path_changed|see docs|nil|
+|path_exists|see docs|nil|
+|path_exists_glob|see docs|nil|
+|path_modified|see docs|nil|
+|unit|see docs|nil|
 
 Also supports:
-- [unit][common_unit]
-- [install][common_install]
+- [unit](#unit)
+- [install](#install)
 
 ### systemd_service
 
@@ -148,42 +153,45 @@ Unit which describes information about a process controlled and supervised by sy
 
 |Attribute|Description|Default|
 |---------|-----------|-------|
-|bus_name|||
-|bus_policy|||
-|exec_reload|||
-|exec_start|||
-|exec_start_post|||
-|exec_start_pre|||
-|exec_stop|||
-|exec_stop_post|||
-|failure_action|||
-|file_descriptor_store_max|||
-|guess_main_pid|||
-|non_blocking|||
-|notify_access|||
-|permissions_start_only|||
-|pid_file|||
-|reboot_argument|||
-|remain_after_exit|||
-|restart|||
-|restart_force_exit_status|||
-|restart_prevent_exit_status|||
-|restart_sec|||
-|root_directory_start_only|||
-|sockets|||
-|start_limit_action|||
-|start_limit_burst|||
-|start_limit_interval|||
-|success_exit_status|||
-|timeout_sec|||
-|timeout_start_sec|||
-|timeout_stop_sec|||
-|type|||
-|watchdog_sec|||
+|bus_name|see docs|nil|
+|bus_policy|see docs|nil|
+|exec_reload|see docs|nil|
+|exec_start|see docs|nil|
+|exec_start_post|see docs|nil|
+|exec_start_pre|see docs|nil|
+|exec_stop|see docs|nil|
+|exec_stop_post|see docs|nil|
+|failure_action|see docs|nil|
+|file_descriptor_store_max|see docs|nil|
+|guess_main_pid|see docs|nil|
+|non_blocking|see docs|nil|
+|notify_access|see docs|nil|
+|permissions_start_only|see docs|nil|
+|pid_file|see docs|nil|
+|reboot_argument|see docs|nil|
+|remain_after_exit|see docs|nil|
+|restart|see docs|nil|
+|restart_force_exit_status|see docs|nil|
+|restart_prevent_exit_status|see docs|nil|
+|restart_sec|see docs|nil|
+|root_directory_start_only|see docs|nil|
+|sockets|see docs|nil|
+|start_limit_action|see docs|nil|
+|start_limit_burst|see docs|nil|
+|start_limit_interval|see docs|nil|
+|success_exit_status|see docs|nil|
+|timeout_sec|see docs|nil|
+|timeout_start_sec|see docs|nil|
+|timeout_stop_sec|see docs|nil|
+|type|see docs|nil|
+|watchdog_sec|see docs|nil|
 
 Also supports:
-- [unit][common_unit]
-- [install][common_install]
+- [unit](#unit)
+- [install](#install)
+- [exec](#exec)
+- [kill](#kill)
+- [resource-control](#resource-control)
 
 ### systemd_slice
 
@@ -194,9 +202,9 @@ for of a group of processes.
 This resource has no specific options.
 
 Also supports:
-- [unit][common_unit]
-- [install][common_install]
-- [resource-control][resource_control]
+- [unit](#unit)
+- [install](#install)
+- [resource-control](#resource-control)
 
 ### systemd_socket
 
@@ -206,60 +214,63 @@ and supervised by systemd for socket-based service activation.
 
 |Attribute|Description|Default|
 |---------|-----------|-------|
-|accept|||
-|backlog|||
-|bind_i_pv6_only|||
-|bind_to_device|||
-|broadcast|||
-|defer_accept_sec|||
-|directory_mode|||
-|exec_start_post|||
-|exec_start_pre|||
-|exec_stop_post|||
-|exec_stop_pre|||
-|free_bind|||
-|iptos|||
-|ipttl|||
-|keep_alive|||
-|keep_alive_interval_sec|||
-|keep_alive_probes|||
-|keep_alive_time_sec|||
-|listen_datagram|||
-|listen_fifo|||
-|listen_message_queue|||
-|listen_netlink|||
-|listen_sequential_packet|||
-|listen_special|||
-|listen_stream|||
-|mark|||
-|max_connections|||
-|message_queue_max_messages|||
-|message_queue_message_size|||
-|no_delay|||
-|pass_credentials|||
-|pass_security|||
-|pipe_size|||
-|priority|||
-|receive_buffer|||
-|remove_on_stop|||
-|reuse_port|||
-|se_linux_context_from_net|||
-|send_buffer|||
-|service|||
-|smack_label|||
-|smack_label_ip_in|||
-|smack_label_ip_out|||
-|socket_group|||
-|socket_mode|||
-|socket_user|||
-|symlinks|||
-|tcp_congestion|||
-|timeout_sec|||
-|transparent|||
+|accept|see docs|nil|
+|backlog|see docs|nil|
+|bind_i_pv6_only|see docs|nil|
+|bind_to_device|see docs|nil|
+|broadcast|see docs|nil|
+|defer_accept_sec|see docs|nil|
+|directory_mode|see docs|nil|
+|exec_start_post|see docs|nil|
+|exec_start_pre|see docs|nil|
+|exec_stop_post|see docs|nil|
+|exec_stop_pre|see docs|nil|
+|free_bind|see docs|nil|
+|iptos|see docs|nil|
+|ipttl|see docs|nil|
+|keep_alive|see docs|nil|
+|keep_alive_interval_sec|see docs|nil|
+|keep_alive_probes|see docs|nil|
+|keep_alive_time_sec|see docs|nil|
+|listen_datagram|see docs|nil|
+|listen_fifo|see docs|nil|
+|listen_message_queue|see docs|nil|
+|listen_netlink|see docs|nil|
+|listen_sequential_packet|see docs|nil|
+|listen_special|see docs|nil|
+|listen_stream|see docs|nil|
+|mark|see docs|nil|
+|max_connections|see docs|nil|
+|message_queue_max_messages|see docs|nil|
+|message_queue_message_size|see docs|nil|
+|no_delay|see docs|nil|
+|pass_credentials|see docs|nil|
+|pass_security|see docs|nil|
+|pipe_size|see docs|nil|
+|priority|see docs|nil|
+|receive_buffer|see docs|nil|
+|remove_on_stop|see docs|nil|
+|reuse_port|see docs|nil|
+|se_linux_context_from_net|see docs|nil|
+|send_buffer|see docs|nil|
+|service|see docs|nil|
+|smack_label|see docs|nil|
+|smack_label_ip_in|see docs|nil|
+|smack_label_ip_out|see docs|nil|
+|socket_group|see docs|nil|
+|socket_mode|see docs|nil|
+|socket_user|see docs|nil|
+|symlinks|see docs|nil|
+|tcp_congestion|see docs|nil|
+|timeout_sec|see docs|nil|
+|transparent|see docs|nil|
 
 Also supports:
-- [unit][common_unit]
-- [install][common_install]
+- [unit](#unit)
+- [install](#install)
+- [exec](#exec)
+- [kill](#kill)
+- [resource-control](#resource-control)
 
 ### systemd_swap
 
@@ -268,14 +279,17 @@ Unit which describes a swap device or file for memory paging.
 
 |Attribute|Description|Default|
 |---------|-----------|-------|
-|options|||
-|priority|||
-|timeout_sec|||
-|what|||
+|options|see docs|nil|
+|priority|see docs|nil|
+|timeout_sec|see docs|nil|
+|what|see docs|nil|
 
 Also supports:
-- [unit][common_unit]
-- [install][common_install]
+- [unit](#unit)
+- [install](#install)
+- [exec](#exec)
+- [kill](#kill)
+- [resource-control](#resource-control)
 
 ### systemd_target
 
@@ -286,8 +300,8 @@ synchronization points during system start-up.
 This unit has no specific options.
 
 Also supports:
-- [unit][common_unit]
-- [install][common_install]
+- [unit](#unit)
+- [install](#install)
 
 ### systemd_timer
 
@@ -297,222 +311,234 @@ activation (typically a service of the same name).
 
 |Attribute|Description|Default|
 |---------|-----------|-------|
-|accuracy_sec|||
-|on_active_sec|||
-|on_boot_sec|||
-|on_calendar|||
-|on_startup_sec|||
-|on_unit_active_sec|||
-|on_unit_inactive_sec|||
-|persistent|||
-|unit|||
-|wake_system|||
+|accuracy_sec|see docs|nil|
+|on_active_sec|see docs|nil|
+|on_boot_sec|see docs|nil|
+|on_calendar|see docs|nil|
+|on_startup_sec|see docs|nil|
+|on_unit_active_sec|see docs|nil|
+|on_unit_inactive_sec|see docs|nil|
+|persistent|see docs|nil|
+|unit|see docs|nil|
+|wake_system|see docs|nil|
 
 Also supports:
-- [unit][common_unit]
-- [install][common_install]
+- [unit](#unit)
+- [install](#install)
 
 ## Common Attributes
 
 ### unit
 
+Common configuration options of all the unit types.
+[Documentation][unit]
+
 |Attribute|Description|Default|
 |---------|-----------|-------|
-|after|||
-|allow_isolate|||
-|assert_ac_power|||
-|assert_architecture|||
-|assert_capability|||
-|assert_directory_not_empty|||
-|assert_file_is_executable|||
-|assert_file_not_empty|||
-|assert_first_boot|||
-|assert_host|||
-|assert_kernel_command_line|||
-|assert_needs_update|||
-|assert_path_exists|||
-|assert_path_exists_glob|||
-|assert_path_is_directory|||
-|assert_path_is_mount_point|||
-|assert_path_is_read_write|||
-|assert_path_is_symbolic_link|||
-|assert_security|||
-|assert_virtualization|||
-|before|||
-|binds_to|||
-|condition_ac_power|||
-|condition_architecture|||
-|condition_capability|||
-|condition_directory_not_empty|||
-|condition_file_is_executable|||
-|condition_file_not_empty|||
-|condition_first_boot|||
-|condition_host|||
-|condition_kernel_command_line|||
-|condition_needs_update|||
-|condition_path_exists|||
-|condition_path_exists_glob|||
-|condition_path_is_directory|||
-|condition_path_is_mount_point|||
-|condition_path_is_read_write|||
-|condition_path_is_symbolic_link|||
-|condition_security|||
-|condition_virtualization|||
-|conflicts|||
-|default_dependencies|||
-|description|||
-|documentation|||
-|ignore_on_isolate|||
-|ignore_on_snapshot|||
-|job_timeout_action|||
-|job_timeout_reboot_argument|||
-|job_timeout_sec|||
-|joins_namespace_of|||
-|on_failure|||
-|on_failure_job_mode|||
-|part_of|||
-|propagates_reload_to|||
-|refuse_manual_start|||
-|refuse_manual_stop|||
-|reload_propagated_from|||
-|requires|||
-|requires_mounts_for|||
-|requires_overridable|||
-|requisite|||
-|requisite_overridable|||
-|source_path|||
-|stop_when_unneeded|||
-|wants|||
+|after|see docs|nil|
+|allow_isolate|see docs|nil|
+|assert_ac_power|see docs|nil|
+|assert_architecture|see docs|nil|
+|assert_capability|see docs|nil|
+|assert_directory_not_empty|see docs|nil|
+|assert_file_is_executable|see docs|nil|
+|assert_file_not_empty|see docs|nil|
+|assert_first_boot|see docs|nil|
+|assert_host|see docs|nil|
+|assert_kernel_command_line|see docs|nil|
+|assert_needs_update|see docs|nil|
+|assert_path_exists|see docs|nil|
+|assert_path_exists_glob|see docs|nil|
+|assert_path_is_directory|see docs|nil|
+|assert_path_is_mount_point|see docs|nil|
+|assert_path_is_read_write|see docs|nil|
+|assert_path_is_symbolic_link|see docs|nil|
+|assert_security|see docs|nil|
+|assert_virtualization|see docs|nil|
+|before|see docs|nil|
+|binds_to|see docs|nil|
+|condition_ac_power|see docs|nil|
+|condition_architecture|see docs|nil|
+|condition_capability|see docs|nil|
+|condition_directory_not_empty|see docs|nil|
+|condition_file_is_executable|see docs|nil|
+|condition_file_not_empty|see docs|nil|
+|condition_first_boot|see docs|nil|
+|condition_host|see docs|nil|
+|condition_kernel_command_line|see docs|nil|
+|condition_needs_update|see docs|nil|
+|condition_path_exists|see docs|nil|
+|condition_path_exists_glob|see docs|nil|
+|condition_path_is_directory|see docs|nil|
+|condition_path_is_mount_point|see docs|nil|
+|condition_path_is_read_write|see docs|nil|
+|condition_path_is_symbolic_link|see docs|nil|
+|condition_security|see docs|nil|
+|condition_virtualization|see docs|nil|
+|conflicts|see docs|nil|
+|default_dependencies|see docs|nil|
+|description|see docs|nil|
+|documentation|see docs|nil|
+|ignore_on_isolate|see docs|nil|
+|ignore_on_snapshot|see docs|nil|
+|job_timeout_action|see docs|nil|
+|job_timeout_reboot_argument|see docs|nil|
+|job_timeout_sec|see docs|nil|
+|joins_namespace_of|see docs|nil|
+|on_failure|see docs|nil|
+|on_failure_job_mode|see docs|nil|
+|part_of|see docs|nil|
+|propagates_reload_to|see docs|nil|
+|refuse_manual_start|see docs|nil|
+|refuse_manual_stop|see docs|nil|
+|reload_propagated_from|see docs|nil|
+|requires|see docs|nil|
+|requires_mounts_for|see docs|nil|
+|requires_overridable|see docs|nil|
+|requisite|see docs|nil|
+|requisite_overridable|see docs|nil|
+|source_path|see docs|nil|
+|stop_when_unneeded|see docs|nil|
+|wants|see docs|nil|
 
 ### install
 
+Carries installation information for units. Used exclusively by enable/disable
+commands of `systemctl`. [Documentation][install]
+
 |Attribute|Description|Default|
 |---------|-----------|-------|
-|aliases||||
-|also|||
-|default_instance|||
-|required_by|||
-|wanted_by|||
+|aliases|see docs|nil|
+|also|see docs|nil|
+|default_instance|see docs|nil|
+|required_by|see docs|nil|
+|wanted_by|see docs|nil|
 
 ### kill
 
+Process killing procedure configuration. [Documentation][kill]
+
 |Attribute|Description|Default|
 |---------|-----------|-------|
-|kill_mode|||
-|kill_signal|||
-|send_sighup|||
-|send_sigkill|||
+|kill_mode|see docs|nil|
+|kill_signal|see docs|nil|
+|send_sighup|see docs|nil|
+|send_sigkill|see docs|nil|
 
 ### exec
 
+Execution environment configuration. [Documentation][exec]
+
 |Attribute|Description|Default|
 |---------|-----------|-------|
-|app_armor_profile|||
-|capabilities|||
-|capability_bounding_set|||
-|cpu_affinity|||
-|cpu_scheduling_policy|||
-|cpu_scheduling_priority|||
-|cpu_scheduling_reset_on_fork|||
-|environment|||
-|environment_file|||
-|group|||
-|ignore_sigpipe|||
-|inaccessible_directories|||
-|io_scheduling_class|||
-|io_scheduling_priority|||
-|limit_as|||
-|limit_core|||
-|limit_cpu|||
-|limit_data|||
-|limit_fsize|||
-|limit_locks|||
-|limit_memlock|||
-|limit_msgqueue|||
-|limit_nice|||
-|limit_nofile|||
-|limit_nproc|||
-|limit_rss|||
-|limit_rtprio|||
-|limit_rttime|||
-|limit_sigpending|||
-|limit_stack|||
-|mount_flags|||
-|nice|||
-|no_new_privileges|||
-|oom_score_adjust|||
-|pam_name|||
-|personality|||
-|private_devices|||
-|private_network|||
-|private_tmp|||
-|protect_home|||
-|protect_system|||
-|read_only_directories|||
-|read_write_directories|||
-|restrict_address_families|||
-|root_directory|||
-|runtime_directory|||
-|runtime_directory_mode|||
-|se_linux_context|||
-|secure_bits|||
-|smack_process_label|||
-|standard_error|||
-|standard_input|||
-|standard_output|||
-|supplementary_groups|||
-|syslog_facility|||
-|syslog_identifier|||
-|syslog_level|||
-|syslog_level_prefix|||
-|system_call_architectures|||
-|system_call_error_number|||
-|system_call_filter|||
-|timer_slack_n_sec|||
-|tty_path|||
-|tty_reset|||
-|ttyv_hangup|||
-|ttyvt_disallocate|||
-|u_mask|||
-|user|||
-|utmp_identifier|||
-|working_directory|||
+|app_armor_profile|see docs|nil|
+|capabilities|see docs|nil|
+|capability_bounding_set|see docs|nil|
+|cpu_affinity|see docs|nil|
+|cpu_scheduling_policy|see docs|nil|
+|cpu_scheduling_priority|see docs|nil|
+|cpu_scheduling_reset_on_fork|see docs|nil|
+|environment|see docs|nil|
+|environment_file|see docs|nil|
+|group|see docs|nil|
+|ignore_sigpipe|see docs|nil|
+|inaccessible_directories|see docs|nil|
+|io_scheduling_class|see docs|nil|
+|io_scheduling_priority|see docs|nil|
+|limit_as|see docs|nil|
+|limit_core|see docs|nil|
+|limit_cpu|see docs|nil|
+|limit_data|see docs|nil|
+|limit_fsize|see docs|nil|
+|limit_locks|see docs|nil|
+|limit_memlock|see docs|nil|
+|limit_msgqueue|see docs|nil|
+|limit_nice|see docs|nil|
+|limit_nofile|see docs|nil|
+|limit_nproc|see docs|nil|
+|limit_rss|see docs|nil|
+|limit_rtprio|see docs|nil|
+|limit_rttime|see docs|nil|
+|limit_sigpending|see docs|nil|
+|limit_stack|see docs|nil|
+|mount_flags|see docs|nil|
+|nice|see docs|nil|
+|no_new_privileges|see docs|nil|
+|oom_score_adjust|see docs|nil|
+|pam_name|see docs|nil|
+|personality|see docs|nil|
+|private_devices|see docs|nil|
+|private_network|see docs|nil|
+|private_tmp|see docs|nil|
+|protect_home|see docs|nil|
+|protect_system|see docs|nil|
+|read_only_directories|see docs|nil|
+|read_write_directories|see docs|nil|
+|restrict_address_families|see docs|nil|
+|root_directory|see docs|nil|
+|runtime_directory|see docs|nil|
+|runtime_directory_mode|see docs|nil|
+|se_linux_context|see docs|nil|
+|secure_bits|see docs|nil|
+|smack_process_label|see docs|nil|
+|standard_error|see docs|nil|
+|standard_input|see docs|nil|
+|standard_output|see docs|nil|
+|supplementary_groups|see docs|nil|
+|syslog_facility|see docs|nil|
+|syslog_identifier|see docs|nil|
+|syslog_level|see docs|nil|
+|syslog_level_prefix|see docs|nil|
+|system_call_architectures|see docs|nil|
+|system_call_error_number|see docs|nil|
+|system_call_filter|see docs|nil|
+|timer_slack_n_sec|see docs|nil|
+|tty_path|see docs|nil|
+|tty_reset|see docs|nil|
+|ttyv_hangup|see docs|nil|
+|ttyvt_disallocate|see docs|nil|
+|u_mask|see docs|nil|
+|user|see docs|nil|
+|utmp_identifier|see docs|nil|
+|working_directory|see docs|nil|
 
 ### resource-control
 
+Resource control unit settings. [Documentation][resource_control]
+
 |Attribute|Description|Default|
 |---------|-----------|-------|
-|block_io_accounting|||
-|block_io_device_weight|||
-|block_io_read_bandwidth|||
-|block_io_weight|||
-|block_io_write_bandwidth|||
-|cpu_accounting|||
-|cpu_quota|||
-|cpu_shares|||
-|delegate|||
-|device_allow|||
-|device_policy|||
-|memory_accounting|||
-|memory_limit|||
-|slice|||
-|startup_block_io_weight|||
-|startup_cpu_shares|||
+|block_io_accounting|see docs|nil|
+|block_io_device_weight|see docs|nil|
+|block_io_read_bandwidth|see docs|nil|
+|block_io_weight|see docs|nil|
+|block_io_write_bandwidth|see docs|nil|
+|cpu_accounting|see docs|nil|
+|cpu_quota|see docs|nil|
+|cpu_shares|see docs|nil|
+|delegate|see docs|nil|
+|device_allow|see docs|nil|
+|device_policy|see docs|nil|
+|memory_accounting|see docs|nil|
+|memory_limit|see docs|nil|
+|slice|see docs|nil|
+|startup_block_io_weight|see docs|nil|
+|startup_cpu_shares|see docs|nil|
 
 ---
 [automount]: http://www.freedesktop.org/software/systemd/man/systemd.automount.html
 [blog]: http://0pointer.de/blog/projects/systemd-for-admins-1.html
 [chef]: https://chef.io
-[common_install]: #install
-[common_unit]: #unit
 [device]: http://www.freedesktop.org/software/systemd/man/systemd.device.html
 [docs]: http://www.freedesktop.org/wiki/Software/systemd/
+[exec]: http://www.freedesktop.org/software/systemd/man/systemd.exec.html
 [ini]: https://en.wikipedia.org/wiki/INI_file
 [install]: http://www.freedesktop.org/software/systemd/man/systemd.unit.html#%5BInstall%5D%20Section%20Options
+[kill]: http://www.freedesktop.org/software/systemd/man/systemd.kill.html
 [mount]: http://www.freedesktop.org/software/systemd/man/systemd.mount.html
 [path]: http://www.freedesktop.org/software/systemd/man/systemd.path.html
 [rhel]: https://access.redhat.com/articles/754933
-[resource_control]: 
+[resource_control]: http://www.freedesktop.org/software/systemd/man/systemd.resource-control.html
 [service]: http://www.freedesktop.org/software/systemd/man/systemd.service.html
 [slice]: http://www.freedesktop.org/software/systemd/man/systemd.slice.html
 [socket]: http://www.freedesktop.org/software/systemd/man/systemd.socket.html

--- a/README.md
+++ b/README.md
@@ -57,11 +57,16 @@ Hey! That sounds pretty easy, right?
 
 ### systemd_automount
 
+Unit which describes a file system automount point controlled by systemd.
+[Documentation][automount]
+
 |Attribute|Description|Default|
 |---------|-----------|-------|
 |where||nil|
 |directory_mode||nil|
 |timeout_idle_sec||nil|
+
+Also supports: [unit][common_unit], [install][common_install]
 
 ### systemd_device
 
@@ -135,10 +140,17 @@ Hey! That sounds pretty easy, right?
 |Attribute|Description|Default|
 |---------|-----------|-------|
 
+
+[automount]: http://www.freedesktop.org/software/systemd/man/systemd.automount.html
 [blog]: http://0pointer.de/blog/projects/systemd-for-admins-1.html
 [chef]: https://chef.io
+[common_install]: #install
+[common_unit]: #unit 
 [docs]: http://www.freedesktop.org/wiki/Software/systemd/
 [ini]: https://en.wikipedia.org/wiki/INI_file
+[install]: http://www.freedesktop.org/software/systemd/man/systemd.unit.html#%5BInstall%5D%20Section%20Options
 [rhel]: https://access.redhat.com/articles/754933
 [travis]: https://travis-ci.org/nathwill/chef-systemd
+[unit]: http://www.freedesktop.org/software/systemd/man/systemd.unit.html#%5BUnit%5D%20Section%20Options
 [units]: http://www.freedesktop.org/software/systemd/man/systemd.unit.html
+

--- a/README.md
+++ b/README.md
@@ -1,7 +1,70 @@
-# systemd
+# systemd chef cookbook [![Build Status](https://travis-ci.org/nathwill/chef-systemd.svg?branch=master)][travis]
 
-Chef cookbook for [systemd][docs].
+A resource-drive [Chef][chef] cookbook for [systemd][docs]. Currently under
+construction; see issues for list of ways to contribute :)
 
-Currently under construction; see issues for list of ways to contribute :)
+Cookbook builds on a core systemd_unit resource in order to provide resources
+for the following unit types:
 
+- automount
+- device
+- mount
+- path
+- service
+- slice
+- socket
+- swap
+- target
+- timer
+
+Recommended reading:
+- This README!
+- [Overview of systemd for RHEL 7][rhel]
+- [systemd docs][docs]
+- [Lennart's blog series][blog]
+- libraries under `libraries/*.rb`
+- test cookbooks under `test/fixtures/cookbooks/setup`
+
+## Recipes
+
+
+## Resources
+
+### Foreword
+
+#### Unit basics
+
+### systemd_automount
+
+### systemd_device
+
+### systemd_mount
+
+### systemd_path
+
+### systemd_service
+
+### systemd_slice
+
+### systemd_socket
+
+### systemd_swap
+
+### systemd_target
+
+### systemd_timer
+
+## Common Attributes
+
+### kill
+
+### exec
+
+### resource-control
+
+
+[blog]: http://0pointer.de/blog/projects/systemd-for-admins-1.html
+[chef]: https://chef.io
 [docs]: http://www.freedesktop.org/wiki/Software/systemd/
+[rhel]: https://access.redhat.com/articles/754933
+[travis]: https://travis-ci.org/nathwill/chef-systemd

--- a/README.md
+++ b/README.md
@@ -72,6 +72,19 @@ attributes.
 
 Hey! That sounds pretty easy, right?
 
+#### A quick word about drop-ins
+
+In systemd, there are 2 ways to override a vendor setting: copying the unit
+from the vendor config location ('/usr/lib/systemd/system') to the local
+configuration path ('/etc/systemd/system') in order to override the entire
+unit configuration, or using a "drop-in" unit to override just the settings
+one specifically wants while keeping track of your explicit requirements and
+still support receiving vendor updates.
+
+The unit resources in this cookbook support a "drop-in" mode for managing
+drop-in units to override units of the same unit type. For more information,
+see the [drop-in](#drop-in) common configuration attributes.
+
 ### systemd_automount
 
 Unit which describes a file system automount point controlled by systemd.
@@ -86,6 +99,7 @@ Unit which describes a file system automount point controlled by systemd.
 Also supports:
 - [unit](#unit)
 - [install](#install)
+- [drop-in](#drop-in)
 
 ### systemd_device
 
@@ -97,6 +111,7 @@ This resource has no specific options.
 Also supports:
 - [unit](#unit)
 - [install](#install)
+- [drop-in](#drop-in)
 
 ### systemd_mount
 
@@ -120,6 +135,7 @@ Unit which describes a file system mount point controlled by systemd.
 Also supports:
 - [unit](#unit)
 - [install](#install)
+- [drop-in](#drop-in)
 - [exec](#exec)
 - [kill](#kill)
 - [resource-control](#resource-control)
@@ -129,7 +145,6 @@ Also supports:
 Unit which describes information about a path monitored by systemd for
 path-based activities.
 [Documentation][path]
-
 
 |Attribute|Description|Default|
 |---------|-----------|-------|
@@ -145,6 +160,7 @@ path-based activities.
 Also supports:
 - [unit](#unit)
 - [install](#install)
+- [drop-in](#drop-in)
 
 ### systemd_service
 
@@ -189,6 +205,7 @@ Unit which describes information about a process controlled and supervised by sy
 Also supports:
 - [unit](#unit)
 - [install](#install)
+- [drop-in](#drop-in)
 - [exec](#exec)
 - [kill](#kill)
 - [resource-control](#resource-control)
@@ -204,6 +221,7 @@ This resource has no specific options.
 Also supports:
 - [unit](#unit)
 - [install](#install)
+- [drop-in](#drop-in)
 - [resource-control](#resource-control)
 
 ### systemd_socket
@@ -268,6 +286,7 @@ and supervised by systemd for socket-based service activation.
 Also supports:
 - [unit](#unit)
 - [install](#install)
+- [drop-in](#drop-in)
 - [exec](#exec)
 - [kill](#kill)
 - [resource-control](#resource-control)
@@ -287,6 +306,7 @@ Unit which describes a swap device or file for memory paging.
 Also supports:
 - [unit](#unit)
 - [install](#install)
+- [drop-in](#drop-in)
 - [exec](#exec)
 - [kill](#kill)
 - [resource-control](#resource-control)
@@ -302,6 +322,7 @@ This unit has no specific options.
 Also supports:
 - [unit](#unit)
 - [install](#install)
+- [drop-in](#drop-in)
 
 ### systemd_timer
 
@@ -325,6 +346,7 @@ activation (typically a service of the same name).
 Also supports:
 - [unit](#unit)
 - [install](#install)
+- [drop-in](#drop-in)
 
 ## Common Attributes
 
@@ -403,16 +425,28 @@ Common configuration options of all the unit types.
 
 ### install
 
-Carries installation information for units. Used exclusively by enable/disable
-commands of `systemctl`. [Documentation][install]
+Carries installation information for units. Used exclusively by
+enable/disable commands of `systemctl`. [Documentation][install]
 
 |Attribute|Description|Default|
 |---------|-----------|-------|
-|aliases|see docs|nil|
+|aliases|array of aliases|[]|
 |also|see docs|nil|
 |default_instance|see docs|nil|
 |required_by|see docs|nil|
 |wanted_by|see docs|nil|
+
+### drop-in
+
+Cookbook-specific attributes that activate and control drop-in mode for units.
+
+|Attribute|Description|Default|
+|---------|-----------|-------|
+|drop_in|boolean which sets where resource is a drop-in unit|false|
+|override|which unit to override, prefix only. suffix determined by resource
+unit type (e.g. "ssh" on a systemd_service -> "ssh.service.d")|nil|
+|overrides|drop-in unit options that require a reset (e.g. "ExecStart" ->
+"ExecStart=" at top of section)|[]|
 
 ### kill
 

--- a/README.md
+++ b/README.md
@@ -88,10 +88,11 @@ Unit which describes a file system mount point controlled by systemd.
 Also supports: [unit][common_unit], [install][common_install]
 
 ### systemd_path
-[Docuemtnation][path]
 
 Unit which describes information about a path monitored by systemd for
 path-based activities.
+[Documentation][path]
+
 
 |Attribute|Description|Default|
 |---------|-----------|-------|

--- a/README.md
+++ b/README.md
@@ -34,6 +34,36 @@ Recommended reading:
 
 #### Unit basics
 
+[Systemd units][units] are files that describe a system resource, like a
+socket, a device, a service, etc. They're written in [INI][ini] format, an
+easy and readable format for describing simple configurations.
+
+Admin-generated configurations are stored under '/etc/systemd/system', and
+override system-level units located under '/usr/lib/systemd/system'.
+
+Every unit type supports at least a "Unit" and "Install" section. The "Unit"
+section carries information about the unit itself, that does not vary between
+unit types; attributes like "Requires", "Description", "Conflicts", or
+assertions about the unit's expectations about its environment. The "Install"
+section carries information about the unit installation, and is only used by
+systemd when a unit is enabled or disabled; attributes like "Wants" or "Alias".
+
+Almost every unit unit type (with a couple minor exceptions in device and
+target), also support a configuration section based on their own "type". For
+example, service units have service-specific configuration in the "Service"
+section for configuration options like "ExecStart", and mount units have a
+"Mount" section for options like "What", and "Where".
+
+There are also 3 special groups of unit options that are common between several
+types of units: exec, kill, and resource-control, which handle common options
+re: execution environment configuration (e.g. "WorkingDirectory"), process
+killing procedure configuration (e.g. "KillSignal"), and resource control
+settings (e.g. "MemoryLimit"). Resources which support these attributes along
+with their type-specific attributes are explicitly noted in the resource
+documentation below, and linked to the documentation for those attributes.
+
+Hey! That sounds pretty easy, right?
+
 ### systemd_automount
 
 ### systemd_device
@@ -66,5 +96,7 @@ Recommended reading:
 [blog]: http://0pointer.de/blog/projects/systemd-for-admins-1.html
 [chef]: https://chef.io
 [docs]: http://www.freedesktop.org/wiki/Software/systemd/
+[ini]: https://en.wikipedia.org/wiki/INI_file
 [rhel]: https://access.redhat.com/articles/754933
 [travis]: https://travis-ci.org/nathwill/chef-systemd
+[units]: http://www.freedesktop.org/software/systemd/man/systemd.unit.html

--- a/libraries/resource_systemd_unit.rb
+++ b/libraries/resource_systemd_unit.rb
@@ -46,12 +46,11 @@ class Chef::Resource
     %w( unit install ).each do |section|
       # convert the section options to resource attributes
       option_attributes Systemd.const_get(section.capitalize)::OPTIONS
+    end
 
-      # define organizational attributes to allow
-      # attributes to be grouped by section
-      define_method(section) do |&b|
-        b.call
-      end
+    # useful for grouping install-section attributes
+    def install
+      yield
     end
 
     def to_hash

--- a/test/fixtures/cookbooks/setup/recipes/default.rb
+++ b/test/fixtures/cookbooks/setup/recipes/default.rb
@@ -43,13 +43,11 @@ systemd_device 'vdb' do
 end
 
 systemd_mount 'tmp-mount' do
-  unit do
-    description 'Test Mount'
-    documentation 'man:hier(7)'
-    default_dependencies 'no'
-    conflicts 'umount.target'
-    before 'local-fs.target umount.target'
-  end
+  description 'Test Mount'
+  documentation 'man:hier(7)'
+  default_dependencies 'no'
+  conflicts 'umount.target'
+  before 'local-fs.target umount.target'
   install do
     wanted_by 'local-fs.target'
   end


### PR DESCRIPTION
ok, couple quick notes:
- added programattically-generated attribute documentation to help people figure out how to get from the camel-case to snake-case version
- added links to official docs for every section
- added section explaining unit basics and drop-ins
- identified a conflict between the "unit" organizational method that was part of the systemd_unit resource, and the "unit" option of the systemd_path resource. so, i removed the organizational one. reasonably enough, now "unit" section options are always top-level, while "install" or "$type" section options can be optionally grouped together as a block to an attribute of the same name, just like before.
