### PR TITLE
add hostnamed recipe

### DIFF
--- a/recipes/hostnamed.rb
+++ b/recipes/hostnamed.rb
@@ -1,0 +1,21 @@
+#
+# Cookbook Name:: systemd
+# Recipe:: hostnamed
+#
+# Copyright 2015 The Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+service 'systemd-hostnamed' do
+  action :start
+end


### PR DESCRIPTION
not much to see here; it's a static unit, so it can't even be enabled.
