### PR TITLE
add init detection helpers

### DIFF
--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -72,8 +72,7 @@ module Systemd
 
     module Init
       def systemd?
-        ::File.symlink?('/sbin/init') &&
-          ::File.readlink('/sbin/init').match(/systemd/)
+        IO.read('/proc/1/comm').chomp == 'systemd'
       end
 
       def upstart?

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -74,21 +74,6 @@ module Systemd
       def systemd?
         IO.read('/proc/1/comm').chomp == 'systemd'
       end
-
-      def upstart?
-        ::File.executable?('/sbin/initctl')
-      end
-
-      def runit?
-        ::File.executable?('/sbin/runit-init')
-      end
-
-      def sysv?
-        !systemd? &&
-          !upstart? &&
-          !runit? &&
-          ::File.directory?('/etc/init.d')
-      end
     end
   end
 end

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -69,6 +69,28 @@ module Systemd
 
     module_function :ini_config, :local_conf_root, :unit_conf_root,
                     :conf_drop_in_root, :conf_path
+
+    module Init
+      def systemd?
+        ::File.symlink?('/sbin/init') &&
+          ::File.readlink('/sbin/init').match(/systemd/)
+      end
+
+      def upstart?
+        ::File.executable?('/sbin/initctl')
+      end
+
+      def runit?
+        ::File.executable?('/sbin/runit-init')
+      end
+
+      def sysv?
+        !systemd? &&
+          !upstart? &&
+          !runit? &&
+          ::File.directory?('/etc/init.d')
+      end
+    end
   end
 end
 
@@ -85,3 +107,5 @@ class String
     gsub(/(^|_)(.)/) { Regexp.last_match(2).upcase }
   end
 end
+
+::Chef::Recipe.send(:include, Systemd::Helpers::Init)


### PR DESCRIPTION
i find myself wishing for these all the time when writing cookbooks; so figured i'd stub 'em out and see how it looked. thoughts? personally, i'm not sure about having the systemd cookbook provide detection for other init systems, but i'm not aware of anywhere else it's done, so maybe it's ok.
