### PR TITLE
ABANDONED: Opts to attrs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,6 @@ sudo: false
 language: ruby
 cache: bundler
 rvm:
-- 2.2.2
+- 2.2.3
 
 script: bundle exec rake default

--- a/Gemfile
+++ b/Gemfile
@@ -7,6 +7,7 @@ group :test do
   gem 'chefspec'
   gem 'foodcritic'
   # new rubocop go boom
+  # https://github.com/bbatsov/rubocop/issues/2218
   gem 'rubocop', '~> 0.33.0'
 end
 

--- a/Gemfile
+++ b/Gemfile
@@ -6,9 +6,7 @@ group :test do
   gem 'rake'
   gem 'chefspec'
   gem 'foodcritic'
-  # new rubocop go boom
-  # https://github.com/bbatsov/rubocop/issues/2218
-  gem 'rubocop', '~> 0.33.0'
+  gem 'rubocop'
 end
 
 group :integration do

--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,8 @@ group :test do
   gem 'rake'
   gem 'chefspec'
   gem 'foodcritic'
-  gem 'rubocop'
+  # new rubocop go boom
+  gem 'rubocop', '~> 0.33.0'
 end
 
 group :integration do

--- a/libraries/resource_systemd_conf.rb
+++ b/libraries/resource_systemd_conf.rb
@@ -51,7 +51,21 @@ class Chef::Resource
     # generates kv pairs from resource attributes
     def options_config(opts = [])
       opts.reject { |o| send(o.underscore.to_sym).nil? }.map do |opt|
-        "#{opt.camelize}=#{send(opt.underscore.to_sym)}"
+        "#{opt.camelize}=#{conf_string(send(opt.underscore.to_sym))}"
+      end
+    end
+
+    # generates config strings from structured data
+    def conf_string(obj)
+      case obj.class
+      when Hash
+        obj.map { |k, v| "#{k}=#{v}" }.join(' ')
+      when Array
+        obj.join(' ')
+      when TrueClass, FalseClass
+        obj ? 'yes' : 'no'
+      else
+        obj.to_s
       end
     end
   end

--- a/libraries/resource_systemd_conf.rb
+++ b/libraries/resource_systemd_conf.rb
@@ -57,7 +57,7 @@ class Chef::Resource
 
     # generates config strings from structured data
     def conf_string(obj)
-      case obj.class
+      case obj
       when Hash
         obj.map { |k, v| "#{k}=#{v}" }.join(' ')
       when Array

--- a/libraries/resource_systemd_mount.rb
+++ b/libraries/resource_systemd_mount.rb
@@ -42,7 +42,7 @@ class Chef::Resource
     auto_attrs = Systemd::Mount::OPTIONS.reject do |o|
       Systemd::Mixin::Exec.instance_methods.include?(o.underscore.to_sym) ||
       Systemd::Mixin::Kill.instance_methods.include?(o.underscore.to_sym) ||
-      Systemd::Mixin::ResourceControl.instance_methods.include?(o.underscore.to_sym)
+      Systemd::Mixin::ResourceControl.instance_methods.include?(o.underscore.to_sym) # rubocop: disable LineLength
     end
 
     option_attributes auto_attrs.to_a

--- a/libraries/resource_systemd_mount.rb
+++ b/libraries/resource_systemd_mount.rb
@@ -35,10 +35,16 @@ class Chef::Resource
       yield
     end
 
-    option_attributes Systemd::Mount::OPTIONS
-
     include Systemd::Mixin::Exec
     include Systemd::Mixin::Kill
     include Systemd::Mixin::ResourceControl
+
+    auto_attrs = Systemd::Mount::OPTIONS.reject do |o|
+      Systemd::Mixin::Exec.instance_methods.include?(o.underscore.to_sym) ||
+      Systemd::Mixin::Kill.instance_methods.include?(o.underscore.to_sym) ||
+      Systemd::Mixin::ResourceControl.instance_methods.include?(o.underscore.to_sym)
+    end
+
+    option_attributes auto_attrs.to_a
   end
 end

--- a/libraries/resource_systemd_mount.rb
+++ b/libraries/resource_systemd_mount.rb
@@ -31,10 +31,14 @@ class Chef::Resource
       :mount
     end
 
-    option_attributes Systemd::Mount::OPTIONS
-
     def mount
       yield
     end
+
+    option_attributes Systemd::Mount::OPTIONS
+
+    include Systemd::Mixin::Exec
+    include Systemd::Mixin::Kill
+    include Systemd::Mixin::ResourceControl
   end
 end

--- a/libraries/resource_systemd_service.rb
+++ b/libraries/resource_systemd_service.rb
@@ -35,10 +35,16 @@ class Chef::Resource
       yield
     end
 
-    option_attributes Systemd::Service::OPTIONS
-
     include Systemd::Mixin::Exec
     include Systemd::Mixin::Kill
     include Systemd::Mixin::ResourceControl
+
+    auto_attrs = Systemd::Service::OPTIONS.reject do |o|
+      Systemd::Mixin::Exec.instance_methods.include?(o.underscore.to_sym) ||
+      Systemd::Mixin::Kill.instance_methods.include?(o.underscore.to_sym) ||
+      Systemd::Mixin::ResourceControl.instance_methods.include?(o.underscore.to_sym)
+    end
+
+    option_attributes auto_attrs.to_a
   end
 end

--- a/libraries/resource_systemd_service.rb
+++ b/libraries/resource_systemd_service.rb
@@ -42,7 +42,7 @@ class Chef::Resource
     auto_attrs = Systemd::Service::OPTIONS.reject do |o|
       Systemd::Mixin::Exec.instance_methods.include?(o.underscore.to_sym) ||
       Systemd::Mixin::Kill.instance_methods.include?(o.underscore.to_sym) ||
-      Systemd::Mixin::ResourceControl.instance_methods.include?(o.underscore.to_sym)
+      Systemd::Mixin::ResourceControl.instance_methods.include?(o.underscore.to_sym) # rubocop: disable LineLength
     end
 
     option_attributes auto_attrs.to_a

--- a/libraries/resource_systemd_service.rb
+++ b/libraries/resource_systemd_service.rb
@@ -31,10 +31,14 @@ class Chef::Resource
       :service
     end
 
-    option_attributes Systemd::Service::OPTIONS
-
     def service
       yield
     end
+
+    option_attributes Systemd::Service::OPTIONS
+
+    include Systemd::Mixin::Exec
+    include Systemd::Mixin::Kill
+    include Systemd::Mixin::ResourceControl
   end
 end

--- a/libraries/resource_systemd_socket.rb
+++ b/libraries/resource_systemd_socket.rb
@@ -31,10 +31,14 @@ class Chef::Resource
       :socket
     end
 
-    option_attributes Systemd::Socket::OPTIONS
-
     def socket
       yield
     end
+
+    option_attributes Systemd::Socket::OPTIONS
+
+    include Systemd::Mixin::Exec
+    include Systemd::Mixin::Kill
+    include Systemd::Mixin::ResourceControl
   end
 end

--- a/libraries/resource_systemd_socket.rb
+++ b/libraries/resource_systemd_socket.rb
@@ -42,7 +42,7 @@ class Chef::Resource
     auto_attrs = Systemd::Socket::OPTIONS.reject do |o|
       Systemd::Mixin::Exec.instance_methods.include?(o.underscore.to_sym) ||
       Systemd::Mixin::Kill.instance_methods.include?(o.underscore.to_sym) ||
-      Systemd::Mixin::ResourceControl.instance_methods.include?(o.underscore.to_sym)
+      Systemd::Mixin::ResourceControl.instance_methods.include?(o.underscore.to_sym) # rubocop: disable LineLength
     end
 
     option_attributes auto_attrs.to_a

--- a/libraries/resource_systemd_socket.rb
+++ b/libraries/resource_systemd_socket.rb
@@ -35,10 +35,16 @@ class Chef::Resource
       yield
     end
 
-    option_attributes Systemd::Socket::OPTIONS
-
     include Systemd::Mixin::Exec
     include Systemd::Mixin::Kill
     include Systemd::Mixin::ResourceControl
+
+    auto_attrs = Systemd::Socket::OPTIONS.reject do |o|
+      Systemd::Mixin::Exec.instance_methods.include?(o.underscore.to_sym) ||
+      Systemd::Mixin::Kill.instance_methods.include?(o.underscore.to_sym) ||
+      Systemd::Mixin::ResourceControl.instance_methods.include?(o.underscore.to_sym)
+    end
+
+    option_attributes auto_attrs.to_a
   end
 end

--- a/libraries/resource_systemd_swap.rb
+++ b/libraries/resource_systemd_swap.rb
@@ -31,10 +31,14 @@ class Chef::Resource
       :swap
     end
 
-    option_attributes Systemd::Swap::OPTIONS
-
     def swap
       yield
     end
+
+    option_attributes Systemd::Swap::OPTIONS
+
+    include Systemd::Mixin::Exec
+    include Systemd::Mixin::Kill
+    include Systemd::Mixin::ResourceControl
   end
 end

--- a/libraries/systemd_exec.rb
+++ b/libraries/systemd_exec.rb
@@ -264,7 +264,7 @@ module Systemd
       def secure_bits(arg = nil)
         set_or_return(
           :secure_bits, arg, kind_of: [String, Array], callbacks: {
-            'valid opts' => lamda do |spec|
+            'valid opts' => lambda do |spec|
               Array(spec).all? do |o|
                 %w( keep-caps keep-caps-locked no-setuid-fixup noroot
                     no-setuid-fixup-locked noroot-locked ).include?(o)

--- a/libraries/systemd_exec.rb
+++ b/libraries/systemd_exec.rb
@@ -93,4 +93,151 @@ module Systemd
       RuntimeDirectoryMode
     )
   end
+
+  def supplementary_groups(arg = nil)
+    set_or_return(
+      :supplementary_groups, arg,
+      kind_of: Array
+    )
+  end
+
+  def nice(arg = nil)
+    set_or_return(
+      :nice, arg,
+      kind_of: Integer,
+      equal_to: -20.upto(19).to_a
+    )
+  end
+
+  def oom_score_adjust(arg = nil)
+    set_or_return(
+      :oom_score_adjust, arg,
+      kind_of: Integer,
+      equal_to: -1_000.upto(1_000).to_a
+    )
+  end
+
+  def io_scheduling_class(arg = nil)
+    set_or_return(
+      :io_scheduling_class, arg,
+      kind_of: String,
+      equal_to: %w( none realtime best-effort idle )
+    )
+  end
+
+  def io_scheduling_priority(arg = nil)
+    set_or_return(
+      :io_scheduling_priority, arg,
+      kind_of: Integer,
+      equal_to: 0.upto(7).to_a
+    )
+  end
+
+  def cpu_scheduling_policy(arg = nil)
+    set_or_return(
+      :cpu_scheduling_policy, arg,
+      kind_of: String,
+      equal_to: %w( other batch idle fifo rr )
+    )
+  end
+
+  def cpu_scheduling_priority(arg = nil)
+    set_or_return(
+      :cpu_scheduling_priority, arg,
+      kind_of: Integer
+    )
+  end
+
+  def cpu_scheduling_reset_on_fork(arg = nil)
+    set_or_return(
+      :cpu_scheduling_reset_on_fork, arg,
+      kind_of: [TrueClass, FalseClass]
+    )
+  end
+
+  def cpu_affinity(arg = nil)
+    set_or_return(
+      :cpu_affinity, arg,
+      kind_of: Array
+    )
+  end
+
+  def standard_input(arg = nil)
+    set_or_return(
+      :standard_input, arg,
+      kind_of: String,
+      equal_to: %w( null tty tty-force tty-fail socket )
+    )
+  end
+
+  def standard_output(arg = nil)
+    set_or_return(
+      :standard_output, arg,
+      kind_of: String,
+      equal_to: %w(
+        inherit null tty journal syslog
+        kmsg journal+console syslog+console
+        kmsg+console socket
+      )
+    )
+  end
+
+  def standard_error(arg = nil)
+    set_or_return(
+      :standard_error, arg,
+      kind_of: String,
+      equal_to: %w( null tty tty-force tty-fail socket )
+    )
+  end
+
+  def tty_reset(arg = nil)
+    set_or_return(
+      :tty_reset, arg,
+      kind_of: [TrueClass, FalseClass]
+    )
+  end
+
+  def ttyv_hangup(arg = nil)
+    set_or_return(
+      :ttyv_hangup, arg,
+      kind_of: [TrueClass, FalseClass]
+    )
+  end
+
+  def ttyvt_disallocate(arg = nil)
+    set_or_return(
+      :ttyvt_disallocate, arg,
+       kind_of: [TrueClass, FalseClass]
+    )
+  end
+
+  def syslog_level(arg = nil)
+    set_or_return(
+      :syslog_level, arg,
+      kind_of: String,
+      equal_to: %w(
+        kern user mail daemon auth syslog lpr news
+        uucp cron authpriv ftp local0 local1 local2
+        local3 local4 local5 local6 local7
+      )
+    )
+  end
+
+  def syslog_level_prefix(arg = nil)
+    set_or_return(
+      :syslog_level_prefix, arg,
+      kind_of: [TrueClass, FalseClass]
+    )
+  end
+
+  def secure_bits(arg = nil)
+    set_or_return(
+      :secure_bits, arg,
+      kind_of: String,
+      equal_to: %w(
+        keep-caps keep-caps-locked no-setuid-fixup
+        no-setuid-fixup-locked noroot noroot-locked
+      )
+    )
+  end
 end

--- a/libraries/systemd_exec.rb
+++ b/libraries/systemd_exec.rb
@@ -95,80 +95,296 @@ module Systemd
       RuntimeDirectoryMode
     )
 
-    attribute :supplementary_groups, kind_of: [String, Array]
-    attribute :nice, kind_of: Integer, equal_to: -20.upto(19).to_a
-    attribute :oom_score_adjust, kind_of: Integer,
-                                 equal_to: -1_000.upto(1_000).to_a
-    attribute :io_scheduling_class, kind_of: [Integer, String],
-                                    equal_to: %w(none realtime best-effort idle)
-                                      .concat(0.upto(3).to_a)
-    attribute :io_scheduling_priority, kind_of: Integer,
-                                       equal_to: 0.upto(7).to_a
-    attribute :cpu_scheduling_policy, kind_of: String,
-                                      equal_to: %w(other batch idle fifo rr)
-    attribute :cpu_scheduling_priority, kind_of: Integer,
-                                        equal_to: 1.upto(99).to_a
-    attribute :cpu_scheduling_reset_on_fork, kind_of: [TrueClass, FalseClass]
-    attribute :cpu_affinity, kind_of: Integer
-    attribute :environment, kind_of: Hash
-    attribute :standard_input, kind_of: String,
-                               equal_to: %w(null tty tty-force tty-fail socket)
-    attribute :standard_output, kind_of: String,
-                                equal_to: %w(
-                                  inherit journal syslog kmsg journal+console
-                                  syslog+console kmsg+console socket null tty
-                                )
-    attribute :standard_error, kind_of: String,
-                               equal_to: %w(
-                                 inherit journal syslog kmsg journal+console
-                                 syslog+console kmsg+console socket null tty
-                               )
-    attribute :tty_reset, kind_of: [TrueClass, FalseClass]
-    attribute :ttyv_hangup, kind_of: [TrueClass, FalseClass]
-    attribute :ttyvt_disallocate, kind_of: [TrueClass, FalseClass]
-    attribute :syslog_facility, kind_of: String,
-                                equal_to: %w(
-                                  kern user mail daemon auth syslog lpr news
-                                  uucp cron authpriv ftp local0 local1 local2
-                                  local3 local4 local5 local6 local7
-                                )
-    attribute :syslog_level, kind_of: String,
-                             equal_to: %w(
-                               emerg alert crit debug
-                               warning notice info err
-                             )
-    attribute :syslog_level_prefix, kind_of: [TrueClass, FalseClass]
-    attribute :timer_slack_n_sec, kind_of: [Integer, String]
-    attribute :secure_bits, kind_of: [String, Array], callbacks: {
-      'valid opts' => lamda do |spec|
-        Array(spec).all? do |o|
-          %w(
-            keep-caps keep-caps-locked
-            no-setuid-fixup noroot
-            no-setuid-fixup-locked
-            noroot-locked
-          ).include?(o)
-        end
-      end
-    }
-    attribute :read_write_directories, kind_of: [String, Array]
-    attribute :read_only_directories, kind_of: [String, Array]
-    attribute :innaccessible_directories, kind_of: [String, Array]
-    attribute :private_tmp, kind_of: [TrueClass, FalseClass]
-    attribute :private_devices, kind_of: [TrueClass, FalseClass]
-    attribute :private_network, kind_of: [TrueClass, FalseClass]
-    attribute :protect_system, kind_of: [TrueClass, FalseClass, String],
-                               equal_to: [true, false, 'full']
-    attribute :protect_home, kind_of: [TrueClass, FalseClass, String],
-                             equal_to: [true, false, 'read-only']
-    attribute :mount_flags, kind_of: String, equal_to: %w(shared slave private)
-    attribute :utmp_mode, kind_of: String, equal_to: %w(init login user)
-    attribute :ignore_sigpipe, kind_of: [TrueClass, FalseClass]
-    attribute :no_new_privileges, kind_of: [TrueClass, FalseClass]
-    attribute :system_call_filter, kind_of: [String, Array]
-    attribute :personality, kind_of: String, equal_to: %w(x86 x86-64)
-    attribute :runtime_directory, kind_of: [String, Array]
-    attribute :runtime_directory_mode, kind_of: [String, Array]
+    def supplementary_groups(arg = nil)
+      set_or_return(
+        :supplementary_groups, arg,
+        kind_of: [String, Array]
+      )
+    end
+
+    def nice(arg = nil)
+      set_or_return(
+        :nice, arg,
+        kind_of: Integer,
+        equal_to: -20.upto(19).to_a
+      )
+    end
+
+    def oom_score_adjust(arg = nil)
+      set_or_return(
+        :oom_score_adjust, arg,
+        kind_of: Integer,
+        equal_to: -1_000.upto(1_000).to_a
+      )
+    end
+
+    def io_scheduling_class(arg = nil)
+      set_or_return(
+        :io_scheduling_class, arg,
+        kind_of: [Integer, String],
+        equal_to: %w(none realtime best-effort idle).concat(0.upto(3).to_a)
+      )
+    end
+
+    def io_scheduling_priority(arg = nil)
+      set_or_return(
+        :io_scheduling_priority, arg,
+        kind_of: Integer,
+        equal_to: 0.upto(7).to_a
+      )
+    end
+
+    def cpu_scheduling_policy(arg = nil)
+      set_or_return(
+        :cpu_scheduling_policy, arg,
+        kind_of: String,
+        equal_to: %w(other batch idle fifo rr)
+      )
+    end
+
+    def cpu_scheduling_priority(arg = nil)
+      set_or_return(
+        :cpu_scheduling_priority, arg,
+        kind_of: Integer,
+        equal_to: 1.upto(99).to_a
+      )
+    end
+
+    def cpu_scheduling_reset_on_fork(arg = nil)
+      set_or_return(
+        :cpu_scheduling_reset_on_fork, arg,
+        kind_of: [TrueClass, FalseClass]
+      )
+    end
+
+    def cpu_affinity(arg = nil)
+      set_or_return(
+        :cpu_affinity, arg,
+        kind_of: Integer
+      )
+    end
+
+    def environment(arg = nil)
+      set_or_return(
+        :environment, arg,
+        kind_of: Hash
+      )
+    end
+
+    def standard_input(arg = nil)
+      set_or_return(
+        :standard_input, arg,
+        kind_of: String,
+        equal_to: %w(null tty tty-force tty-fail socket)
+      )
+    end
+
+    def standard_output(arg = nil)
+      set_or_return(
+        :standard_output, arg,
+        kind_of: String,
+        equal_to: %w(
+          inherit journal syslog kmsg journal+console
+          syslog+console kmsg+console socket null tty
+        )
+      )
+    end
+
+    def standard_error(arg = nil)
+      set_or_return(
+        :standard_error, arg,
+        kind_of: String,
+        equal_to: %w(
+          inherit journal syslog kmsg journal+console
+          syslog+console kmsg+console socket null tty
+        )
+      )
+    end
+
+    def tty_reset(arg = nil)
+      set_or_return(
+        :tty_reset, arg,
+        kind_of: [TrueClass, FalseClass]
+      )
+    end
+
+    def ttyv_hangup(arg = nil)
+      set_or_return(
+        :ttyv_hangup, arg,
+        kind_of: [TrueClass, FalseClass]
+      )
+    end
+
+    def ttyvt_disallocate(arg = nil)
+      set_or_return(
+        :ttyvt_disallocate, arg,
+        kind_of: [TrueClass, FalseClass]
+      )
+    end
+
+    def syslog_facility(arg = nil)
+      set_or_return(
+        :syslog_facility, arg,
+        kind_of: String,
+        equal_to: %w(
+          kern user mail daemon auth syslog lpr news
+          uucp cron authpriv ftp local0 local1 local2
+          local3 local4 local5 local6 local7
+        )
+      )
+    end
+
+    def syslog_level(arg = nil)
+      set_or_return(
+        :syslog_level, arg,
+        kind_of: String,
+        equal_to: %w(emerg alert crit debug warning notice info err)
+      )
+    end
+
+    def syslog_level_prefix(arg = nil)
+      set_or_return(
+        :syslog_level_prefix, arg,
+        kind_of: [TrueClass, FalseClass]
+      )
+    end
+
+    def timer_slack_n_sec(arg = nil)
+      set_or_return(
+        :timer_slack_n_sec, arg,
+        kind_of: [Integer, String]
+      )
+    end
+
+    def secure_bits(arg = nil)
+      set_or_return(
+        :secure_bits, arg, kind_of: [String, Array], callbacks: {
+          'valid opts' => lamda do |spec|
+            Array(spec).all? do |o|
+              %w( keep-caps keep-caps-locked no-setuid-fixup noroot
+                  no-setuid-fixup-locked noroot-locked ).include?(o)
+            end
+          end
+        }
+      )
+    end
+
+    def read_write_directories(arg = nil)
+      set_or_return(
+        :read_write_directories, arg,
+        kind_of: [String, Array]
+      )
+    end
+
+    def read_only_directories(arg = nil)
+      set_or_return(
+        :read_only_directories, arg,
+        kind_of: [String, Array]
+      )
+    end
+
+    def inaccessible_directories(arg = nil)
+      set_or_return(
+        :inaccessible_directories, arg,
+        kind_of: [String, Array]
+      )
+    end
+
+    def private_tmp(arg = nil)
+      set_or_return(
+        :private_tmp, arg,
+        kind_of: [TrueClass, FalseClass]
+      )
+    end
+
+    def private_devices(arg = nil)
+      set_or_return(
+        :private_devices, arg,
+        kind_of: [TrueClass, FalseClass]
+      )
+    end
+
+    def private_network(arg = nil)
+      set_or_return(
+        :private_network, arg,
+        kind_of: [TrueClass, FalseClass]
+      )
+    end
+
+    def protect_system(arg = nil)
+      set_or_return(
+        :protect_system, arg,
+        kind_of: [TrueClass, FalseClass, String],
+        equal_to: [true, false, 'full']
+      )
+    end
+
+    def protect_home(arg = nil)
+      set_or_return(
+        :protect_home, arg,
+        kind_of: [TrueClass, FalseClass, String],
+        equal_to: [true, false, 'read-only']
+      )
+    end
+
+    def mount_flags(arg = nil)
+      set_or_return(
+        :mount_flags, arg,
+        kind_of: String,
+        equal_to: %w(shared slave private)
+      )
+    end
+
+    def utmp_mode(arg = nil)
+      set_or_return(
+        :utmp_mode, arg,
+        kind_of: String,
+        equal_to: %w(init login user)
+      )
+    end
+
+    def ignore_sigpipe(arg = nil)
+      set_or_return(
+        :ignore_sigpipe, arg,
+        kind_of: [TrueClass, FalseClass]
+      )
+    end
+
+    def no_new_privileges(arg = nil)
+      set_or_return(
+        :no_new_privileges, arg,
+        kind_of: [TrueClass, FalseClass]
+      )
+    end
+
+    def system_call_filter(arg = nil)
+      set_or_return(
+        :system_call_filter, arg,
+        kind_of: [String, Array]
+      )
+    end
+
+    def personality(arg = nil)
+      set_or_return(
+        :personality, arg,
+        kind_of: String,
+        equal_to: %w(x86 x86-64)
+      )
+    end
+
+    def runtime_directory(arg = nil)
+      set_or_return(
+        :runtime_directory, arg,
+        kind_of: [String, Array]
+      )
+    end
+
+    def runtime_directory_mode(arg = nil)
+      set_or_return(
+        :runtime_directory_mode, arg,
+        kind_of: [String, Array]
+      )
+    end
   end
   # rubocop: enable ModuleLength
 end

--- a/libraries/systemd_exec.rb
+++ b/libraries/systemd_exec.rb
@@ -18,6 +18,8 @@
 # limitations under the License.
 #
 
+require_relative 'systemd_mixin'
+
 module Systemd
   # rubocop: disable ModuleLength
   module Exec
@@ -94,296 +96,300 @@ module Systemd
       RuntimeDirectory
       RuntimeDirectoryMode
     )
+  end
 
-    def supplementary_groups(arg = nil)
-      set_or_return(
-        :supplementary_groups, arg,
-        kind_of: [String, Array]
-      )
-    end
-
-    def nice(arg = nil)
-      set_or_return(
-        :nice, arg,
-        kind_of: Integer,
-        equal_to: -20.upto(19).to_a
-      )
-    end
-
-    def oom_score_adjust(arg = nil)
-      set_or_return(
-        :oom_score_adjust, arg,
-        kind_of: Integer,
-        equal_to: -1_000.upto(1_000).to_a
-      )
-    end
-
-    def io_scheduling_class(arg = nil)
-      set_or_return(
-        :io_scheduling_class, arg,
-        kind_of: [Integer, String],
-        equal_to: %w(none realtime best-effort idle).concat(0.upto(3).to_a)
-      )
-    end
-
-    def io_scheduling_priority(arg = nil)
-      set_or_return(
-        :io_scheduling_priority, arg,
-        kind_of: Integer,
-        equal_to: 0.upto(7).to_a
-      )
-    end
-
-    def cpu_scheduling_policy(arg = nil)
-      set_or_return(
-        :cpu_scheduling_policy, arg,
-        kind_of: String,
-        equal_to: %w(other batch idle fifo rr)
-      )
-    end
-
-    def cpu_scheduling_priority(arg = nil)
-      set_or_return(
-        :cpu_scheduling_priority, arg,
-        kind_of: Integer,
-        equal_to: 1.upto(99).to_a
-      )
-    end
-
-    def cpu_scheduling_reset_on_fork(arg = nil)
-      set_or_return(
-        :cpu_scheduling_reset_on_fork, arg,
-        kind_of: [TrueClass, FalseClass]
-      )
-    end
-
-    def cpu_affinity(arg = nil)
-      set_or_return(
-        :cpu_affinity, arg,
-        kind_of: Integer
-      )
-    end
-
-    def environment(arg = nil)
-      set_or_return(
-        :environment, arg,
-        kind_of: Hash
-      )
-    end
-
-    def standard_input(arg = nil)
-      set_or_return(
-        :standard_input, arg,
-        kind_of: String,
-        equal_to: %w(null tty tty-force tty-fail socket)
-      )
-    end
-
-    def standard_output(arg = nil)
-      set_or_return(
-        :standard_output, arg,
-        kind_of: String,
-        equal_to: %w(
-          inherit journal syslog kmsg journal+console
-          syslog+console kmsg+console socket null tty
+  module Mixin
+    module Exec
+      def supplementary_groups(arg = nil)
+        set_or_return(
+          :supplementary_groups, arg,
+          kind_of: [String, Array]
         )
-      )
-    end
+      end
 
-    def standard_error(arg = nil)
-      set_or_return(
-        :standard_error, arg,
-        kind_of: String,
-        equal_to: %w(
-          inherit journal syslog kmsg journal+console
-          syslog+console kmsg+console socket null tty
+      def nice(arg = nil)
+        set_or_return(
+          :nice, arg,
+          kind_of: Integer,
+          equal_to: -20.upto(19).to_a
         )
-      )
-    end
+      end
 
-    def tty_reset(arg = nil)
-      set_or_return(
-        :tty_reset, arg,
-        kind_of: [TrueClass, FalseClass]
-      )
-    end
-
-    def ttyv_hangup(arg = nil)
-      set_or_return(
-        :ttyv_hangup, arg,
-        kind_of: [TrueClass, FalseClass]
-      )
-    end
-
-    def ttyvt_disallocate(arg = nil)
-      set_or_return(
-        :ttyvt_disallocate, arg,
-        kind_of: [TrueClass, FalseClass]
-      )
-    end
-
-    def syslog_facility(arg = nil)
-      set_or_return(
-        :syslog_facility, arg,
-        kind_of: String,
-        equal_to: %w(
-          kern user mail daemon auth syslog lpr news
-          uucp cron authpriv ftp local0 local1 local2
-          local3 local4 local5 local6 local7
+      def oom_score_adjust(arg = nil)
+        set_or_return(
+          :oom_score_adjust, arg,
+          kind_of: Integer,
+          equal_to: -1_000.upto(1_000).to_a
         )
-      )
-    end
+      end
 
-    def syslog_level(arg = nil)
-      set_or_return(
-        :syslog_level, arg,
-        kind_of: String,
-        equal_to: %w(emerg alert crit debug warning notice info err)
-      )
-    end
+      def io_scheduling_class(arg = nil)
+        set_or_return(
+          :io_scheduling_class, arg,
+          kind_of: [Integer, String],
+          equal_to: %w(none realtime best-effort idle).concat(0.upto(3).to_a)
+        )
+      end
 
-    def syslog_level_prefix(arg = nil)
-      set_or_return(
-        :syslog_level_prefix, arg,
-        kind_of: [TrueClass, FalseClass]
-      )
-    end
+      def io_scheduling_priority(arg = nil)
+        set_or_return(
+          :io_scheduling_priority, arg,
+          kind_of: Integer,
+          equal_to: 0.upto(7).to_a
+        )
+      end
 
-    def timer_slack_n_sec(arg = nil)
-      set_or_return(
-        :timer_slack_n_sec, arg,
-        kind_of: [Integer, String]
-      )
-    end
+      def cpu_scheduling_policy(arg = nil)
+        set_or_return(
+          :cpu_scheduling_policy, arg,
+          kind_of: String,
+          equal_to: %w(other batch idle fifo rr)
+        )
+      end
 
-    def secure_bits(arg = nil)
-      set_or_return(
-        :secure_bits, arg, kind_of: [String, Array], callbacks: {
-          'valid opts' => lamda do |spec|
-            Array(spec).all? do |o|
-              %w( keep-caps keep-caps-locked no-setuid-fixup noroot
-                  no-setuid-fixup-locked noroot-locked ).include?(o)
+      def cpu_scheduling_priority(arg = nil)
+        set_or_return(
+          :cpu_scheduling_priority, arg,
+          kind_of: Integer,
+          equal_to: 1.upto(99).to_a
+        )
+      end
+
+      def cpu_scheduling_reset_on_fork(arg = nil)
+        set_or_return(
+          :cpu_scheduling_reset_on_fork, arg,
+          kind_of: [TrueClass, FalseClass]
+        )
+      end
+
+      def cpu_affinity(arg = nil)
+        set_or_return(
+          :cpu_affinity, arg,
+          kind_of: Integer
+        )
+      end
+
+      def environment(arg = nil)
+        set_or_return(
+          :environment, arg,
+          kind_of: Hash
+        )
+      end
+
+      def standard_input(arg = nil)
+        set_or_return(
+          :standard_input, arg,
+          kind_of: String,
+          equal_to: %w(null tty tty-force tty-fail socket)
+        )
+      end
+
+      def standard_output(arg = nil)
+        set_or_return(
+          :standard_output, arg,
+          kind_of: String,
+          equal_to: %w(
+            inherit journal syslog kmsg journal+console
+            syslog+console kmsg+console socket null tty
+          )
+        )
+      end
+
+      def standard_error(arg = nil)
+        set_or_return(
+          :standard_error, arg,
+          kind_of: String,
+          equal_to: %w(
+            inherit journal syslog kmsg journal+console
+            syslog+console kmsg+console socket null tty
+          )
+        )
+      end
+
+      def tty_reset(arg = nil)
+        set_or_return(
+          :tty_reset, arg,
+          kind_of: [TrueClass, FalseClass]
+        )
+      end
+
+      def ttyv_hangup(arg = nil)
+        set_or_return(
+          :ttyv_hangup, arg,
+          kind_of: [TrueClass, FalseClass]
+        )
+      end
+
+      def ttyvt_disallocate(arg = nil)
+        set_or_return(
+          :ttyvt_disallocate, arg,
+          kind_of: [TrueClass, FalseClass]
+        )
+      end
+
+      def syslog_facility(arg = nil)
+        set_or_return(
+          :syslog_facility, arg,
+          kind_of: String,
+          equal_to: %w(
+            kern user mail daemon auth syslog lpr news
+            uucp cron authpriv ftp local0 local1 local2
+            local3 local4 local5 local6 local7
+          )
+        )
+      end
+
+      def syslog_level(arg = nil)
+        set_or_return(
+          :syslog_level, arg,
+          kind_of: String,
+          equal_to: %w(emerg alert crit debug warning notice info err)
+        )
+      end
+
+      def syslog_level_prefix(arg = nil)
+        set_or_return(
+          :syslog_level_prefix, arg,
+          kind_of: [TrueClass, FalseClass]
+        )
+      end
+
+      def timer_slack_n_sec(arg = nil)
+        set_or_return(
+          :timer_slack_n_sec, arg,
+          kind_of: [Integer, String]
+        )
+      end
+
+      def secure_bits(arg = nil)
+        set_or_return(
+          :secure_bits, arg, kind_of: [String, Array], callbacks: {
+            'valid opts' => lamda do |spec|
+              Array(spec).all? do |o|
+                %w( keep-caps keep-caps-locked no-setuid-fixup noroot
+                    no-setuid-fixup-locked noroot-locked ).include?(o)
+              end
             end
-          end
-        }
-      )
-    end
+          }
+        )
+      end
 
-    def read_write_directories(arg = nil)
-      set_or_return(
-        :read_write_directories, arg,
-        kind_of: [String, Array]
-      )
-    end
+      def read_write_directories(arg = nil)
+        set_or_return(
+          :read_write_directories, arg,
+          kind_of: [String, Array]
+        )
+      end
 
-    def read_only_directories(arg = nil)
-      set_or_return(
-        :read_only_directories, arg,
-        kind_of: [String, Array]
-      )
-    end
+      def read_only_directories(arg = nil)
+        set_or_return(
+          :read_only_directories, arg,
+          kind_of: [String, Array]
+        )
+      end
 
-    def inaccessible_directories(arg = nil)
-      set_or_return(
-        :inaccessible_directories, arg,
-        kind_of: [String, Array]
-      )
-    end
+      def inaccessible_directories(arg = nil)
+        set_or_return(
+          :inaccessible_directories, arg,
+          kind_of: [String, Array]
+        )
+      end
 
-    def private_tmp(arg = nil)
-      set_or_return(
-        :private_tmp, arg,
-        kind_of: [TrueClass, FalseClass]
-      )
-    end
+      def private_tmp(arg = nil)
+        set_or_return(
+          :private_tmp, arg,
+          kind_of: [TrueClass, FalseClass]
+        )
+      end
 
-    def private_devices(arg = nil)
-      set_or_return(
-        :private_devices, arg,
-        kind_of: [TrueClass, FalseClass]
-      )
-    end
+      def private_devices(arg = nil)
+        set_or_return(
+          :private_devices, arg,
+          kind_of: [TrueClass, FalseClass]
+        )
+      end
 
-    def private_network(arg = nil)
-      set_or_return(
-        :private_network, arg,
-        kind_of: [TrueClass, FalseClass]
-      )
-    end
+      def private_network(arg = nil)
+        set_or_return(
+          :private_network, arg,
+          kind_of: [TrueClass, FalseClass]
+        )
+      end
 
-    def protect_system(arg = nil)
-      set_or_return(
-        :protect_system, arg,
-        kind_of: [TrueClass, FalseClass, String],
-        equal_to: [true, false, 'full']
-      )
-    end
+      def protect_system(arg = nil)
+        set_or_return(
+          :protect_system, arg,
+          kind_of: [TrueClass, FalseClass, String],
+          equal_to: [true, false, 'full']
+        )
+      end
 
-    def protect_home(arg = nil)
-      set_or_return(
-        :protect_home, arg,
-        kind_of: [TrueClass, FalseClass, String],
-        equal_to: [true, false, 'read-only']
-      )
-    end
+      def protect_home(arg = nil)
+        set_or_return(
+          :protect_home, arg,
+          kind_of: [TrueClass, FalseClass, String],
+          equal_to: [true, false, 'read-only']
+        )
+      end
 
-    def mount_flags(arg = nil)
-      set_or_return(
-        :mount_flags, arg,
-        kind_of: String,
-        equal_to: %w(shared slave private)
-      )
-    end
+      def mount_flags(arg = nil)
+        set_or_return(
+          :mount_flags, arg,
+          kind_of: String,
+          equal_to: %w(shared slave private)
+        )
+      end
 
-    def utmp_mode(arg = nil)
-      set_or_return(
-        :utmp_mode, arg,
-        kind_of: String,
-        equal_to: %w(init login user)
-      )
-    end
+      def utmp_mode(arg = nil)
+        set_or_return(
+          :utmp_mode, arg,
+          kind_of: String,
+          equal_to: %w(init login user)
+        )
+      end
 
-    def ignore_sigpipe(arg = nil)
-      set_or_return(
-        :ignore_sigpipe, arg,
-        kind_of: [TrueClass, FalseClass]
-      )
-    end
+      def ignore_sigpipe(arg = nil)
+        set_or_return(
+          :ignore_sigpipe, arg,
+          kind_of: [TrueClass, FalseClass]
+        )
+      end
 
-    def no_new_privileges(arg = nil)
-      set_or_return(
-        :no_new_privileges, arg,
-        kind_of: [TrueClass, FalseClass]
-      )
-    end
+      def no_new_privileges(arg = nil)
+        set_or_return(
+          :no_new_privileges, arg,
+          kind_of: [TrueClass, FalseClass]
+        )
+      end
 
-    def system_call_filter(arg = nil)
-      set_or_return(
-        :system_call_filter, arg,
-        kind_of: [String, Array]
-      )
-    end
+      def system_call_filter(arg = nil)
+        set_or_return(
+          :system_call_filter, arg,
+          kind_of: [String, Array]
+        )
+      end
 
-    def personality(arg = nil)
-      set_or_return(
-        :personality, arg,
-        kind_of: String,
-        equal_to: %w(x86 x86-64)
-      )
-    end
+      def personality(arg = nil)
+        set_or_return(
+          :personality, arg,
+          kind_of: String,
+          equal_to: %w(x86 x86-64)
+        )
+      end
 
-    def runtime_directory(arg = nil)
-      set_or_return(
-        :runtime_directory, arg,
-        kind_of: [String, Array]
-      )
-    end
+      def runtime_directory(arg = nil)
+        set_or_return(
+          :runtime_directory, arg,
+          kind_of: [String, Array]
+        )
+      end
 
-    def runtime_directory_mode(arg = nil)
-      set_or_return(
-        :runtime_directory_mode, arg,
-        kind_of: [String, Array]
-      )
+      def runtime_directory_mode(arg = nil)
+        set_or_return(
+          :runtime_directory_mode, arg,
+          kind_of: [String, Array]
+        )
+      end
     end
   end
   # rubocop: enable ModuleLength

--- a/libraries/systemd_exec.rb
+++ b/libraries/systemd_exec.rb
@@ -19,6 +19,7 @@
 #
 
 module Systemd
+  # rubocop: disable ModuleLength
   module Exec
     OPTIONS ||= %w(
       WorkingDirectory
@@ -79,6 +80,7 @@ module Systemd
       ProtectHome
       MountFlags
       UtmpIdentifier
+      UtmpMode
       SELinuxContext
       AppArmorProfile
       SmackProcessLabel
@@ -92,152 +94,81 @@ module Systemd
       RuntimeDirectory
       RuntimeDirectoryMode
     )
-  end
 
-  def supplementary_groups(arg = nil)
-    set_or_return(
-      :supplementary_groups, arg,
-      kind_of: Array
-    )
+    attribute :supplementary_groups, kind_of: [String, Array]
+    attribute :nice, kind_of: Integer, equal_to: -20.upto(19).to_a
+    attribute :oom_score_adjust, kind_of: Integer,
+                                 equal_to: -1_000.upto(1_000).to_a
+    attribute :io_scheduling_class, kind_of: [Integer, String],
+                                    equal_to: %w(none realtime best-effort idle)
+                                      .concat(0.upto(3).to_a)
+    attribute :io_scheduling_priority, kind_of: Integer,
+                                       equal_to: 0.upto(7).to_a
+    attribute :cpu_scheduling_policy, kind_of: String,
+                                      equal_to: %w(other batch idle fifo rr)
+    attribute :cpu_scheduling_priority, kind_of: Integer,
+                                        equal_to: 1.upto(99).to_a
+    attribute :cpu_scheduling_reset_on_fork, kind_of: [TrueClass, FalseClass]
+    attribute :cpu_affinity, kind_of: Integer
+    attribute :environment, kind_of: Hash
+    attribute :standard_input, kind_of: String,
+                               equal_to: %w(null tty tty-force tty-fail socket)
+    attribute :standard_output, kind_of: String,
+                                equal_to: %w(
+                                  inherit journal syslog kmsg journal+console
+                                  syslog+console kmsg+console socket null tty
+                                )
+    attribute :standard_error, kind_of: String,
+                               equal_to: %w(
+                                 inherit journal syslog kmsg journal+console
+                                 syslog+console kmsg+console socket null tty
+                               )
+    attribute :tty_reset, kind_of: [TrueClass, FalseClass]
+    attribute :ttyv_hangup, kind_of: [TrueClass, FalseClass]
+    attribute :ttyvt_disallocate, kind_of: [TrueClass, FalseClass]
+    attribute :syslog_facility, kind_of: String,
+                                equal_to: %w(
+                                  kern user mail daemon auth syslog lpr news
+                                  uucp cron authpriv ftp local0 local1 local2
+                                  local3 local4 local5 local6 local7
+                                )
+    attribute :syslog_level, kind_of: String,
+                             equal_to: %w(
+                               emerg alert crit debug
+                               warning notice info err
+                             )
+    attribute :syslog_level_prefix, kind_of: [TrueClass, FalseClass]
+    attribute :timer_slack_n_sec, kind_of: [Integer, String]
+    attribute :secure_bits, kind_of: [String, Array], callbacks: {
+      'valid opts' => lamda do |spec|
+        Array(spec).all? do |o|
+          %w(
+            keep-caps keep-caps-locked
+            no-setuid-fixup noroot
+            no-setuid-fixup-locked
+            noroot-locked
+          ).include?(o)
+        end
+      end
+    }
+    attribute :read_write_directories, kind_of: [String, Array]
+    attribute :read_only_directories, kind_of: [String, Array]
+    attribute :innaccessible_directories, kind_of: [String, Array]
+    attribute :private_tmp, kind_of: [TrueClass, FalseClass]
+    attribute :private_devices, kind_of: [TrueClass, FalseClass]
+    attribute :private_network, kind_of: [TrueClass, FalseClass]
+    attribute :protect_system, kind_of: [TrueClass, FalseClass, String],
+                               equal_to: [true, false, 'full']
+    attribute :protect_home, kind_of: [TrueClass, FalseClass, String],
+                             equal_to: [true, false, 'read-only']
+    attribute :mount_flags, kind_of: String, equal_to: %w(shared slave private)
+    attribute :utmp_mode, kind_of: String, equal_to: %w(init login user)
+    attribute :ignore_sigpipe, kind_of: [TrueClass, FalseClass]
+    attribute :no_new_privileges, kind_of: [TrueClass, FalseClass]
+    attribute :system_call_filter, kind_of: [String, Array]
+    attribute :personality, kind_of: String, equal_to: %w(x86 x86-64)
+    attribute :runtime_directory, kind_of: [String, Array]
+    attribute :runtime_directory_mode, kind_of: [String, Array]
   end
-
-  def nice(arg = nil)
-    set_or_return(
-      :nice, arg,
-      kind_of: Integer,
-      equal_to: -20.upto(19).to_a
-    )
-  end
-
-  def oom_score_adjust(arg = nil)
-    set_or_return(
-      :oom_score_adjust, arg,
-      kind_of: Integer,
-      equal_to: -1_000.upto(1_000).to_a
-    )
-  end
-
-  def io_scheduling_class(arg = nil)
-    set_or_return(
-      :io_scheduling_class, arg,
-      kind_of: String,
-      equal_to: %w( none realtime best-effort idle )
-    )
-  end
-
-  def io_scheduling_priority(arg = nil)
-    set_or_return(
-      :io_scheduling_priority, arg,
-      kind_of: Integer,
-      equal_to: 0.upto(7).to_a
-    )
-  end
-
-  def cpu_scheduling_policy(arg = nil)
-    set_or_return(
-      :cpu_scheduling_policy, arg,
-      kind_of: String,
-      equal_to: %w( other batch idle fifo rr )
-    )
-  end
-
-  def cpu_scheduling_priority(arg = nil)
-    set_or_return(
-      :cpu_scheduling_priority, arg,
-      kind_of: Integer
-    )
-  end
-
-  def cpu_scheduling_reset_on_fork(arg = nil)
-    set_or_return(
-      :cpu_scheduling_reset_on_fork, arg,
-      kind_of: [TrueClass, FalseClass]
-    )
-  end
-
-  def cpu_affinity(arg = nil)
-    set_or_return(
-      :cpu_affinity, arg,
-      kind_of: Array
-    )
-  end
-
-  def standard_input(arg = nil)
-    set_or_return(
-      :standard_input, arg,
-      kind_of: String,
-      equal_to: %w( null tty tty-force tty-fail socket )
-    )
-  end
-
-  def standard_output(arg = nil)
-    set_or_return(
-      :standard_output, arg,
-      kind_of: String,
-      equal_to: %w(
-        inherit null tty journal syslog
-        kmsg journal+console syslog+console
-        kmsg+console socket
-      )
-    )
-  end
-
-  def standard_error(arg = nil)
-    set_or_return(
-      :standard_error, arg,
-      kind_of: String,
-      equal_to: %w( null tty tty-force tty-fail socket )
-    )
-  end
-
-  def tty_reset(arg = nil)
-    set_or_return(
-      :tty_reset, arg,
-      kind_of: [TrueClass, FalseClass]
-    )
-  end
-
-  def ttyv_hangup(arg = nil)
-    set_or_return(
-      :ttyv_hangup, arg,
-      kind_of: [TrueClass, FalseClass]
-    )
-  end
-
-  def ttyvt_disallocate(arg = nil)
-    set_or_return(
-      :ttyvt_disallocate, arg,
-       kind_of: [TrueClass, FalseClass]
-    )
-  end
-
-  def syslog_level(arg = nil)
-    set_or_return(
-      :syslog_level, arg,
-      kind_of: String,
-      equal_to: %w(
-        kern user mail daemon auth syslog lpr news
-        uucp cron authpriv ftp local0 local1 local2
-        local3 local4 local5 local6 local7
-      )
-    )
-  end
-
-  def syslog_level_prefix(arg = nil)
-    set_or_return(
-      :syslog_level_prefix, arg,
-      kind_of: [TrueClass, FalseClass]
-    )
-  end
-
-  def secure_bits(arg = nil)
-    set_or_return(
-      :secure_bits, arg,
-      kind_of: String,
-      equal_to: %w(
-        keep-caps keep-caps-locked no-setuid-fixup
-        no-setuid-fixup-locked noroot noroot-locked
-      )
-    )
-  end
+  # rubocop: enable ModuleLength
 end

--- a/libraries/systemd_kill.rb
+++ b/libraries/systemd_kill.rb
@@ -27,4 +27,28 @@ module Systemd
       SendSIGKILL
     )
   end
+
+  def kill_mode(arg = nil)
+    set_or_return(
+      :kill_mode, arg,
+      :kind_of => String,
+      :equal_to => %w( control-group process mixed none )
+    )
+  end
+
+  def send_sighup(arg = nil)
+    set_or_return(
+      :send_sighup, arg,
+      :kind_of => String,
+      :equal_to => %w( yes no )
+    )
+  end
+
+  def send_sigkill(arg = nil)
+    set_or_return(
+      :send_sigkill, arg,
+      :kind_of => String,
+      :equal_to => %w( yes no )
+    )
+  end
 end

--- a/libraries/systemd_kill.rb
+++ b/libraries/systemd_kill.rb
@@ -39,16 +39,14 @@ module Systemd
   def send_sighup(arg = nil)
     set_or_return(
       :send_sighup, arg,
-      kind_of: String,
-      equal_to: %w( yes no )
+      kind_of: [TrueClass, FalseClass]
     )
   end
 
   def send_sigkill(arg = nil)
     set_or_return(
       :send_sigkill, arg,
-      kind_of: String,
-      equal_to: %w( yes no )
+      kind_of: [TrueClass, FalseClass]
     )
   end
 end

--- a/libraries/systemd_kill.rb
+++ b/libraries/systemd_kill.rb
@@ -31,24 +31,24 @@ module Systemd
   def kill_mode(arg = nil)
     set_or_return(
       :kill_mode, arg,
-      :kind_of => String,
-      :equal_to => %w( control-group process mixed none )
+      kind_of: String,
+      equal_to: %w( control-group process mixed none )
     )
   end
 
   def send_sighup(arg = nil)
     set_or_return(
       :send_sighup, arg,
-      :kind_of => String,
-      :equal_to => %w( yes no )
+      kind_of: String,
+      equal_to: %w( yes no )
     )
   end
 
   def send_sigkill(arg = nil)
     set_or_return(
       :send_sigkill, arg,
-      :kind_of => String,
-      :equal_to => %w( yes no )
+      kind_of: String,
+      equal_to: %w( yes no )
     )
   end
 end

--- a/libraries/systemd_kill.rb
+++ b/libraries/systemd_kill.rb
@@ -18,6 +18,8 @@
 # limitations under the License.
 #
 
+require_relative 'systemd_mixin'
+
 module Systemd
   module Kill
     OPTIONS ||= %w(
@@ -28,25 +30,29 @@ module Systemd
     )
   end
 
-  def kill_mode(arg = nil)
-    set_or_return(
-      :kill_mode, arg,
-      kind_of: String,
-      equal_to: %w( control-group process mixed none )
-    )
-  end
+  module Mixin
+    module Kill
+      def kill_mode(arg = nil)
+        set_or_return(
+          :kill_mode, arg,
+          kind_of: String,
+          equal_to: %w( control-group process mixed none )
+        )
+      end
 
-  def send_sighup(arg = nil)
-    set_or_return(
-      :send_sighup, arg,
-      kind_of: [TrueClass, FalseClass]
-    )
-  end
+      def send_sighup(arg = nil)
+        set_or_return(
+          :send_sighup, arg,
+          kind_of: [TrueClass, FalseClass]
+        )
+      end
 
-  def send_sigkill(arg = nil)
-    set_or_return(
-      :send_sigkill, arg,
-      kind_of: [TrueClass, FalseClass]
-    )
+      def send_sigkill(arg = nil)
+        set_or_return(
+          :send_sigkill, arg,
+          kind_of: [TrueClass, FalseClass]
+        )
+      end
+    end
   end
 end

--- a/libraries/systemd_mixin.rb
+++ b/libraries/systemd_mixin.rb
@@ -1,0 +1,3 @@
+module Systemd
+  module Mixin; end
+end

--- a/libraries/systemd_resource_control.rb
+++ b/libraries/systemd_resource_control.rb
@@ -18,6 +18,8 @@
 # limitations under the License.
 #
 
+require_relative 'systemd_mixin'
+
 module Systemd
   module ResourceControl
     OPTIONS ||= %w(
@@ -40,69 +42,73 @@ module Systemd
     )
   end
 
-  def cpu_accounting(arg = nil)
-    set_or_return(
-      :cpu_accounting, arg,
-      kind_of: [TrueClass, FalseClass]
-    )
-  end
+  module Mixin
+    module ResourceControl
+      def cpu_accounting(arg = nil)
+        set_or_return(
+          :cpu_accounting, arg,
+          kind_of: [TrueClass, FalseClass]
+        )
+      end
 
-  def cpu_shares(arg = nil)
-    set_or_return(
-      :cpu_shares, arg,
-      kind_of: Integer
-    )
-  end
+      def cpu_shares(arg = nil)
+        set_or_return(
+          :cpu_shares, arg,
+          kind_of: Integer
+        )
+      end
 
-  def startup_cpu_shares(arg = nil)
-    set_or_return(
-      :startup_cpu_shares, arg,
-      kind_of: Integer
-    )
-  end
+      def startup_cpu_shares(arg = nil)
+        set_or_return(
+          :startup_cpu_shares, arg,
+          kind_of: Integer
+        )
+      end
 
-  def memory_accounting(arg = nil)
-    set_or_return(
-      :memory_accounting, arg,
-      kind_of: [TrueClass, FalseClass]
-    )
-  end
+      def memory_accounting(arg = nil)
+        set_or_return(
+          :memory_accounting, arg,
+          kind_of: [TrueClass, FalseClass]
+        )
+      end
 
-  def block_io_accounting(arg = nil)
-    set_or_return(
-      :block_io_accounting, arg,
-      kind_of: [TrueClass, FalseClass]
-    )
-  end
+      def block_io_accounting(arg = nil)
+        set_or_return(
+          :block_io_accounting, arg,
+          kind_of: [TrueClass, FalseClass]
+        )
+      end
 
-  def block_io_weight(arg = nil)
-    set_or_return(
-      :block_io_weight, arg,
-      kind_of: Integer,
-      equal_to: 10.upto(1_000)
-    )
-  end
+      def block_io_weight(arg = nil)
+        set_or_return(
+          :block_io_weight, arg,
+          kind_of: Integer,
+          equal_to: 10.upto(1_000)
+        )
+      end
 
-  def startup_block_io_weight(arg = nil)
-    set_or_return(
-      :startup_block_io_weight, arg,
-      kind_of: Integer,
-      equal_to: 10.upto(1_000)
-    )
-  end
+      def startup_block_io_weight(arg = nil)
+        set_or_return(
+          :startup_block_io_weight, arg,
+          kind_of: Integer,
+          equal_to: 10.upto(1_000)
+        )
+      end
 
-  def device_policy(arg = nil)
-    set_or_return(
-      :device_policy, arg,
-      kind_of: String,
-      equal_to: %w( strict closed auto )
-    )
-  end
+      def device_policy(arg = nil)
+        set_or_return(
+          :device_policy, arg,
+          kind_of: String,
+          equal_to: %w( strict closed auto )
+        )
+      end
 
-  def delegate(arg = nil)
-    set_or_return(
-      :delegate, arg,
-      kind_of: [TrueClass, FalseClass]
-    )
+      def delegate(arg = nil)
+        set_or_return(
+          :delegate, arg,
+          kind_of: [TrueClass, FalseClass]
+        )
+      end
+    end
   end
 end

--- a/libraries/systemd_resource_control.rb
+++ b/libraries/systemd_resource_control.rb
@@ -39,4 +39,61 @@ module Systemd
       Delegate
     )
   end
+
+  def cpu_accounting(arg = nil)
+    set_or_return(
+      :cpu_accounting, arg,
+      kind_of: [TrueClass, FalseClass]
+    )
+  end
+
+  def cpu_shares(arg = nil)
+    set_or_return(
+      :cpu_shares, arg,
+      kind_of: Integer
+    )
+  end
+
+  def startup_cpu_shares(arg = nil)
+    set_or_return(
+      :startup_cpu_shares, arg,
+      kind_of: Integer
+    )
+  end
+
+  def memory_accounting(arg = nil)
+    set_or_return(
+      :memory_accounting, arg,
+      kind_of: [TrueClass, FalseClass]
+    )
+  end
+
+  def block_io_accounting(arg = nil)
+    set_or_return(
+      :block_io_accounting, arg,
+      kind_of: [TrueClass, FalseClass]
+    )
+  end
+
+  def block_io_weight(arg = nil)
+    set_or_return(
+      :block_io_weight, arg,
+      kind_of: Integer
+    )
+  end
+
+  def startup_block_io_weight(arg = nil)
+    set_or_return(
+      :startup_block_io_weight, arg,
+      kind_of: Integer
+    )
+  end
+
+  def device_policy(arg = nil)
+    set_or_return(
+      :device_policy, arg,
+      kind_of: String,
+      equal_to: %w( strict closed auto )
+    )
+  end
 end

--- a/libraries/systemd_resource_control.rb
+++ b/libraries/systemd_resource_control.rb
@@ -78,14 +78,16 @@ module Systemd
   def block_io_weight(arg = nil)
     set_or_return(
       :block_io_weight, arg,
-      kind_of: Integer
+      kind_of: Integer,
+      equal_to: 10.upto(1_000)
     )
   end
 
   def startup_block_io_weight(arg = nil)
     set_or_return(
       :startup_block_io_weight, arg,
-      kind_of: Integer
+      kind_of: Integer,
+      equal_to: 10.upto(1_000)
     )
   end
 
@@ -94,6 +96,13 @@ module Systemd
       :device_policy, arg,
       kind_of: String,
       equal_to: %w( strict closed auto )
+    )
+  end
+
+  def delegate(arg = nil)
+    set_or_return(
+      :delegate, arg,
+      kind_of: [TrueClass, FalseClass]
     )
   end
 end

--- a/test/fixtures/cookbooks/setup/recipes/service.rb
+++ b/test/fixtures/cookbooks/setup/recipes/service.rb
@@ -14,6 +14,7 @@ systemd_service 'test-unit' do
     type 'oneshot'
     exec_start '/usr/bin/true'
     # exec option
+    private_tmp true
     user 'nobody'
     # kill option
     kill_signal 'SIGTERM'


### PR DESCRIPTION
still a lot of work to do before this is ready to merge, but the general idea is to add extra value where possible while maintaining attribute names. doing so through the modules, which will then be able to be used as mixins to help reduce duplication, since there's some overlap between certain resources' options, particularly for kill, resource-control, and exec unit options.

edit: longest... runon... ever.
