### PR TITLE
Add TasksAccounting configuration options

### DIFF
--- a/README.md
+++ b/README.md
@@ -925,6 +925,7 @@ end
 |default_environment|see docs|nil|
 |default_cpu_accounting|see docs|nil|
 |default_block_io_accounting|see docs|nil|
+|default_tasks_accounting|see docs|nil|
 |default_memory_accounting|see docs|nil|
 |default_limit_cpu|see docs|nil|
 |default_limit_fsize|see docs|nil|
@@ -1398,6 +1399,8 @@ Resource control unit settings. [Documentation][resource_control]
 |device_policy|see docs|nil|
 |memory_accounting|see docs|nil|
 |memory_limit|see docs|nil|
+|tasks_accounting|see docs|nil|
+|tasks_limit|see docs|nil|
 |slice|see docs|nil|
 |net_class|see docs|nil|
 |startup_block_io_weight|see docs|nil|

--- a/libraries/systemd.rb
+++ b/libraries/systemd.rb
@@ -336,6 +336,19 @@ module Systemd
       'CPUQuota' => {},
       'MemoryAccounting' => { kind_of: [TrueClass, FalseClass] },
       'MemoryLimit' => {},
+      'TasksAccounting' => { kind_of: [TrueClass, FalseClass] },
+      'TasksMax' => { kind_of: [Integer, String],
+                      callbacks: {
+                        'is a valid symbol' =>
+                        lambda do |val|
+                          if val.is_a?(String)
+                            val == 'infinity'
+                          else
+                            true
+                          end
+                        end
+                      }
+                    },
       'BlockIOAccounting' => { kind_of: [TrueClass, FalseClass] },
       'BlockIOWeight' => { kind_of: Integer, equal_to: 10.upto(1_000) },
       'StartupBlockIOWeight' => { kind_of: Integer, equal_to: 10.upto(1_000) },
@@ -626,6 +639,7 @@ module Systemd
       'DefaultCPUAccounting' => { kind_of: [TrueClass, FalseClass] },
       'DefaultBlockIOAccounting' => { kind_of: [TrueClass, FalseClass] },
       'DefaultMemoryAccounting' => { kind_of: [TrueClass, FalseClass] },
+      'DefaultTasksAccounting' => { kind_of: [TrueClass, FalseClass] },
       'DefaultLimitCPU' => {},
       'DefaultLimitFSIZE' => {},
       'DefaultLimitDATA' => {},


### PR DESCRIPTION
TasksAccounting was added in systemd 227 and allows one to limit the
number of tasks started in a cgroup.
