### PR TITLE
Support new ChrashChangeVT configuration option

### DIFF
--- a/README.md
+++ b/README.md
@@ -907,6 +907,7 @@ end
 |crash_reboot|see docs|nil|
 |show_status|see docs|nil|
 |crash_ch_vt|see docs|nil|
+|crash_change_vt|see docs|nil|
 |default_standard_output|see docs|nil|
 |default_standard_error|see docs|nil|
 |cpu_affinity|see docs|nil|

--- a/libraries/systemd.rb
+++ b/libraries/systemd.rb
@@ -617,6 +617,7 @@ module Systemd
       'CrashReboot' => { kind_of: [TrueClass, FalseClass] },
       'ShowStatus' => {},
       'CrashChVT' => {},
+      'CrashChangeVT' => {},
       'DefaultStandardOutput' => {},
       'DefaultStandardError' => {},
       'CPUAffinity' => { kind_of: [String, Array] },


### PR DESCRIPTION
In systemd 227, CrashChVT became CrashChangeVT; however, the old option
is still supported.
