### PR TITLE
Add Writable configuration directive for socket units

### DIFF
--- a/libraries/systemd.rb
+++ b/libraries/systemd.rb
@@ -555,6 +555,7 @@ module Systemd
                        'SocketMode' => { kind_of: [String, Integer] },
                        'DirectoryMode' => { kind_of: [String, Integer] },
                        'Accept' => { kind_of: [TrueClass, FalseClass] },
+                       'Writable' => { kind_of: [TrueClass, FalseClass] },
                        'MaxConnections' => { kind_of: Integer },
                        'KeepAlive' => { kind_of: [TrueClass, FalseClass] },
                        'KeepAliveTimeSec' => { kind_of: Integer },


### PR DESCRIPTION
Systemd 227 added the Writable directive for socket units which (in
conjunction with ListenSpecial) allows opening the specified file RDWR.
