### PR TITLE
Add backward-compatibility to Chef 11.x

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -14,6 +14,6 @@ supports 'ubuntu', '>= 15.04'
 end
 
 unless defined?(Ridley::Chef::Cookbook::Metadata)
-  source_url       'https://github.com/nathwill/chef-systemd'
-  issues_url       'https://github.com/nathwill/chef-systemd/issues'
+  source_url       'https://github.com/nathwill/chef-systemd' if respond_to?(:source_url)
+  issues_url       'https://github.com/nathwill/chef-systemd/issues' if respond_to?(:issues_url)
 end


### PR DESCRIPTION
See https://github.com/chef/chef/issues/2937#issuecomment-74933735

We are experiencing using the cookbook with AWS OpsWorks. OpsWorks latest chef version is 11.10.4. Trying to run a converge with `chef-systemd` ends with an error:

```
[2015-11-20T16:32:31-05:00] ERROR: Could not read /opt/aws/opsworks/current/merged-cookbooks/systemd into a Chef object: undefined method `source_url' for #<Chef::Cookbook::Metadata:0x007f5af04dabc8>
```

This PR adds the backward compatibility to it by checking if `source_url` and `issues_url` are available attributes.
