### PR TITLE
comment/minor cleanup

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,7 @@ group :test do
   gem 'rake'
   gem 'chefspec'
   gem 'foodcritic'
-  gem 'rubocop'
+  gem 'rubocop', '~> 0.34.2'
 end
 
 group :integration do

--- a/attributes/bootchart.rb
+++ b/attributes/bootchart.rb
@@ -16,6 +16,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# Ref: http://man7.org/linux/man-pages/man5/bootchart.conf.5.html
 default['systemd']['bootchart'].tap do |b|
   b['samples'] = nil
   b['frequency'] = nil

--- a/attributes/coredump.rb
+++ b/attributes/coredump.rb
@@ -16,6 +16,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# Ref: http://www.freedesktop.org/software/systemd/man/coredump.conf.html
 default['systemd']['coredump'].tap do |c|
   c['storage'] = nil
   c['compress'] = true

--- a/attributes/hostname.rb
+++ b/attributes/hostname.rb
@@ -16,4 +16,5 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# Ref: http://www.freedesktop.org/software/systemd/man/hostname.html
 default['systemd']['hostname'] = nil

--- a/attributes/journal_gatewayd.rb
+++ b/attributes/journal_gatewayd.rb
@@ -16,6 +16,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# Ref: http://www.freedesktop.org/software/systemd/man/systemd-journal-gatewayd.service.html
 default['systemd']['journal_gatewayd'].tap do |jg|
   jg['package'] = 'systemd-journal-gateway'
 

--- a/attributes/journald.rb
+++ b/attributes/journald.rb
@@ -16,6 +16,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# Ref: http://www.freedesktop.org/software/systemd/man/journald.conf.html
 default['systemd']['journald'].tap do |j|
   j['storage'] = 'auto'
   j['compress'] = nil

--- a/attributes/locale.rb
+++ b/attributes/locale.rb
@@ -16,6 +16,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# Ref: http://www.freedesktop.org/software/systemd/man/locale.conf.html
 default['systemd']['locale'].tap do |l|
   l['lang'] = 'en_US.UTF-8'
   l['language'] = nil

--- a/attributes/logind.rb
+++ b/attributes/logind.rb
@@ -16,6 +16,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# Ref: http://www.freedesktop.org/software/systemd/man/logind.conf.html
 default['systemd']['logind'].tap do |l|
   l['n_auto_v_ts'] = 0
   l['reserve_vt'] = nil

--- a/attributes/real_time_clock.rb
+++ b/attributes/real_time_clock.rb
@@ -16,6 +16,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# Ref: http://www.freedesktop.org/software/systemd/man/timedatectl.html#set-local-rtc%20[BOOL]
 default['systemd']['real_time_clock'].tap do |rtc|
   rtc['mode'] = 'utc'
   rtc['adjust_system_clock'] = false

--- a/attributes/real_time_clock.rb
+++ b/attributes/real_time_clock.rb
@@ -16,7 +16,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Ref: http://www.freedesktop.org/software/systemd/man/timedatectl.html#set-local-rtc%20[BOOL]
+# Ref: http://www.freedesktop.org/software/systemd/man/timedatectl.html
 default['systemd']['real_time_clock'].tap do |rtc|
   rtc['mode'] = 'utc'
   rtc['adjust_system_clock'] = false

--- a/attributes/resolved.rb
+++ b/attributes/resolved.rb
@@ -16,6 +16,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# Ref: http://www.freedesktop.org/software/systemd/man/resolved.conf.html
 default['systemd']['resolved'].tap do |r|
   r['dns'] = %w( 8.8.8.8 8.8.4.4 )
   r['fallback_dns'] = %w( 208.67.222.222 208.67.220.220 )

--- a/attributes/sleep.rb
+++ b/attributes/sleep.rb
@@ -16,6 +16,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# Ref: http://www.freedesktop.org/software/systemd/man/systemd-sleep.conf.html
 default['systemd']['sleep'].tap do |s|
   s['suspend_mode'] = nil
   s['hibernate_mode'] = nil

--- a/attributes/system.rb
+++ b/attributes/system.rb
@@ -16,6 +16,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# Ref: http://www.freedesktop.org/software/systemd/man/systemd-system.conf.html
 default['systemd']['system'].tap do |s|
   s['log_level'] = nil
   s['log_target'] = nil

--- a/attributes/time.rb
+++ b/attributes/time.rb
@@ -16,6 +16,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# Ref: http://www.freedesktop.org/software/systemd/man/timedatectl.html
+# Ref: http://www.freedesktop.org/software/systemd/man/timesyncd.conf.html
 default['systemd'].tap do |s|
   # See timedatectl list-timezones
   s['timezone'] = 'UTC'

--- a/attributes/udev.rb
+++ b/attributes/udev.rb
@@ -16,6 +16,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# Ref: http://www.freedesktop.org/software/systemd/man/udev.conf.html
+# Ref: http://www.freedesktop.org/software/systemd/man/systemd-udevd.service.html
 default['systemd']['udev'].tap do |u|
   u['udev_log'] = nil
   u['options'].tap do |o|

--- a/attributes/user.rb
+++ b/attributes/user.rb
@@ -16,6 +16,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# Ref: http://www.freedesktop.org/software/systemd/man/systemd-system.conf.html
 default['systemd']['user'].tap do |u|
   u['log_level'] = nil
   u['log_target'] = nil

--- a/attributes/vconsole.rb
+++ b/attributes/vconsole.rb
@@ -16,6 +16,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# Ref: http://www.freedesktop.org/software/systemd/man/vconsole.conf.html
 default['systemd']['vconsole'].tap do |v|
   v['keymap'] = 'us'
   v['keymap_toggle'] = nil

--- a/chefignore
+++ b/chefignore
@@ -51,8 +51,10 @@ spec/*
 spec/fixtures/*
 test/*
 features/*
+Gemfile
 Guardfile
 Procfile
+Rakefile
 
 # SCM #
 #######

--- a/libraries/binfmt.rb
+++ b/libraries/binfmt.rb
@@ -56,11 +56,8 @@ class Chef::Resource
     }
 
     def as_string
-      str = []
-
-      %w( name type offset magic mask interpreter flags ).each do |a|
-        str << send(a.to_sym)
-      end
+      str = %w( name type offset magic mask interpreter flags )
+            .map { |a| send(a.to_sym) }
 
       ":#{str.join(':')}"
     end

--- a/libraries/daemons.rb
+++ b/libraries/daemons.rb
@@ -20,10 +20,12 @@
 # limitations under the License.
 #
 
+# resources for systemd daemons
+
 require_relative 'systemd'
 require_relative 'daemon'
 
-# resources for systemd daemons
+# TODO: deduplicate the boilerplate
 class Chef::Resource
   # resource for configuring systemd-journald
   # http://www.freedesktop.org/software/systemd/man/systemd-journald.service.html
@@ -50,7 +52,7 @@ class Chef::Resource
       :logind
     end
 
-    def label(_ = nil)
+    def label
       'Login'
     end
 
@@ -66,7 +68,7 @@ class Chef::Resource
       :resolved
     end
 
-    def label(_ = nil)
+    def label
       'Resolve'
     end
 
@@ -82,7 +84,7 @@ class Chef::Resource
       :timesyncd
     end
 
-    def label(_ = nil)
+    def label
       'Time'
     end
 

--- a/libraries/handlers.rb
+++ b/libraries/handlers.rb
@@ -17,6 +17,8 @@
 # limitations under the License.
 #
 
+# Event-handler actions
+# Ref: https://docs.chef.io/handlers.html#event-handlers
 require 'chef/resource/execute'
 
 module SystemdHandlers

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -81,8 +81,12 @@ module Systemd
       end
     end
 
+    def module_loaded?(mod)
+      IO.read('/proc/modules').match(Regexp.new("^#{mod}\s"))
+    end
+
     module_function :ini_config, :local_conf_root, :unit_conf_root,
-                    :conf_drop_in_root, :conf_path
+                    :conf_drop_in_root, :conf_path, :module_loaded?
 
     module Init
       # systemd makes this way too easy

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -45,7 +45,8 @@ module Systemd
       end.join("\n")
     end
 
-    # systemd's administrator-managed load path
+    # systemd's administrator-managed load path. leave /usr/lib
+    # for the vendors to use, the way god^wlennart intended ;)
     def local_conf_root
       '/etc/systemd'
     end

--- a/libraries/modules.rb
+++ b/libraries/modules.rb
@@ -20,6 +20,7 @@
 
 require 'chef/resource/lwrp_base'
 require 'chef/provider/lwrp_base'
+require_relative 'helpers'
 
 class Chef::Resource
   # manage system modules
@@ -69,7 +70,7 @@ class Chef::Provider
 
       r.modules.each do |m|
         e = execute "modprobe #{m}" do
-          not_if { loaded?(m) }
+          not_if { Systemd::Helpers.module_loaded?(m) }
         end
 
         updated << m if e.updated_by_last_action?
@@ -85,19 +86,13 @@ class Chef::Provider
 
       r.modules.each do |m|
         e = execute "modprobe -r #{m}" do
-          only_if { loaded?(m) }
+          only_if { Systemd::Helpers.module_loaded?(m) }
         end
 
         updated << m if e.updated_by_last_action?
       end
 
       new_resource.updated_by_last_action(!updated.empty?)
-    end
-
-    private
-
-    def loaded?(mod)
-      IO.read('/proc/modules').match(Regexp.new("^#{mod}\s"))
     end
   end
 end

--- a/libraries/modules.rb
+++ b/libraries/modules.rb
@@ -69,7 +69,7 @@ class Chef::Provider
 
       r.modules.each do |m|
         e = execute "modprobe #{m}" do
-          not_if { IO.read('/proc/modules').match(Regexp.new("^#{m}\s")) }
+          not_if { loaded?(m) }
         end
 
         updated << m if e.updated_by_last_action?
@@ -85,13 +85,19 @@ class Chef::Provider
 
       r.modules.each do |m|
         e = execute "modprobe -r #{m}" do
-          only_if { IO.read('/proc/modules').match(Regexp.new("^#{m}\s")) }
+          only_if { loaded?(m) }
         end
 
         updated << m if e.updated_by_last_action?
       end
 
       new_resource.updated_by_last_action(!updated.empty?)
+    end
+
+    private
+
+    def loaded?(mod)
+      IO.read('/proc/modules').match(Regexp.new("^#{mod}\s"))
     end
   end
 end

--- a/libraries/sysctl.rb
+++ b/libraries/sysctl.rb
@@ -23,7 +23,7 @@ require 'chef/provider/lwrp_base'
 require 'mixlib/shellout'
 
 class Chef::Resource
-  # resource for configuring kernel parameters at boot
+  # resource for configuring kernel parameters
   # http://man7.org/linux/man-pages/man5/sysctl.d.5.html
   class SystemdSysctl < Chef::Resource::LWRPBase
     resource_name :systemd_sysctl
@@ -35,6 +35,10 @@ class Chef::Resource
 
     def to_kv
       "#{name}=#{Array(value).join(' ')}"
+    end
+
+    def to_cli
+      "#{name}='#{Array(value).join(' ')}'"
     end
   end
 end
@@ -70,7 +74,7 @@ class Chef::Provider
       current = Mixlib::ShellOut.new("sysctl -n #{r.name}")
                 .tap(&:run_command).stdout.chomp
 
-      e = execute "sysctl -e -w #{r.to_kv}" do
+      e = execute "sysctl -e -w #{r.to_cli}" do
         not_if { current == Array(r.value).join(' ') }
       end
 

--- a/libraries/systemd.rb
+++ b/libraries/systemd.rb
@@ -20,10 +20,11 @@
 
 require_relative 'helpers'
 
-# systemd configuration for various resources
-# these hashes are passed into the the option_attributes
-# class method in Chef::Resource::Systemd::Conf to generate
-# LWRP attributes with minimal effort.
+# systemd configuration for various resources; these hashes
+# are passed into the the option_attributes class method in
+# Chef::Resource::Systemd::Conf to more easily generate the
+# literal metric tons of custom resource attributes needed.
+
 module Systemd
   module Automount
     OPTIONS ||= {

--- a/libraries/units.rb
+++ b/libraries/units.rb
@@ -25,10 +25,12 @@
 # limitations under the License.
 #
 
+# resources for management of systemd units
+
 require_relative 'systemd'
 require_relative 'unit'
 
-# resources for management of systemd units
+# TODO: deduplicate the boilerplate
 class Chef::Resource
   # resource for configuration of systemd automount units
   # http://www.freedesktop.org/software/systemd/man/systemd.automount.html

--- a/libraries/utils.rb
+++ b/libraries/utils.rb
@@ -23,6 +23,7 @@
 require_relative 'systemd'
 require_relative 'util'
 
+# TODO: deduplicate the boilerplate
 class Chef::Resource
   # resource for managing systemd-bootchart
   # http://www.freedesktop.org/software/systemd/man/systemd-bootchart.html

--- a/recipes/binfmt.rb
+++ b/recipes/binfmt.rb
@@ -16,6 +16,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# oneshot service that runs at boot
 service 'systemd-binfmt' do
   action :enable
 end

--- a/recipes/daemon_reload.rb
+++ b/recipes/daemon_reload.rb
@@ -16,10 +16,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Registers a converge_complete handler to determine if a
-# daemon-reload is required for `auto_reload false` units.
-# Requires Chef >= 12.5.
-
+# In combination with `auto_reload false`, this is useful for
+# managing large numbers of units, where it is otherwise too
+# expensive to run a daemon-reload on every resource change.
 if Chef::VERSION.to_f >= 12.5
   Chef.event_handler do
     on :converge_complete do
@@ -34,7 +33,7 @@ else
     action :nothing
   end
 
-  ruby_block 'notify-delayed-conditional-daemon-reload' do
+  ruby_block 'notify-delayed-conditional-systemd-daemon-reload' do
     block do
       Chef::Log.info('Triggering delayed daemon-reload evaluation.')
     end

--- a/recipes/hostname.rb
+++ b/recipes/hostname.rb
@@ -22,14 +22,9 @@ hostname = node['systemd']['hostname']
 file path do
   content hostname
   not_if { hostname.nil? }
-end
-
-execute "hostnamectl set-hostname #{hostname}" do
-  action :nothing
-  subscribes :run, "file[#{path}]", :immediately
+  notifies :restart, 'service[systemd-hostnamed]', :immediately
 end
 
 service 'systemd-hostnamed' do
   action :enable
-  subscribes :restart, "file[#{path}]", :immediately
 end

--- a/recipes/hostname.rb
+++ b/recipes/hostname.rb
@@ -22,7 +22,14 @@ hostname = node['systemd']['hostname']
 file path do
   content hostname
   not_if { hostname.nil? }
-  notifies :restart, 'service[systemd-hostnamed]', :immediately
+  notifies :run, 'execute[set-hostname]', :immediately
+end
+
+# apply immediately; works on all platforms
+execute "set-hostname" do
+  command "hostnamectl set-hostname #{hostname}"
+  action :nothing
+  not_if { hostname.nil? }
 end
 
 service 'systemd-hostnamed' do

--- a/recipes/hostname.rb
+++ b/recipes/hostname.rb
@@ -26,7 +26,7 @@ file path do
 end
 
 # apply immediately; works on all platforms
-execute "set-hostname" do
+execute 'set-hostname' do
   command "hostnamectl set-hostname #{hostname}"
   action :nothing
   not_if { hostname.nil? }

--- a/recipes/locale.rb
+++ b/recipes/locale.rb
@@ -22,6 +22,7 @@ opts = l.reject { |_, v| v.nil? }
 
 file '/etc/locale.conf' do
   content opts.map { |k, v| "#{k.upcase}=\"#{v}\"" }.join("\n")
+  not_if { opts.empty? }
   notifies :restart, 'service[systemd-localed]', :immediately
 end
 

--- a/recipes/logind.rb
+++ b/recipes/logind.rb
@@ -25,5 +25,5 @@ systemd_logind 'logind' do
 end
 
 service 'systemd-logind' do
-  action [:enable, :start]
+  action :enable
 end

--- a/recipes/machined.rb
+++ b/recipes/machined.rb
@@ -17,5 +17,5 @@
 # limitations under the License.
 
 service 'systemd-machined' do
-  action [:enable, :start]
+  action :enable
 end

--- a/recipes/timesyncd.rb
+++ b/recipes/timesyncd.rb
@@ -21,10 +21,10 @@ systemd_timesyncd 'timesyncd' do
   node['systemd']['timesyncd'].each_pair do |config, value|
     send(config.to_sym, value) unless value.nil?
   end
+  notifies :restart, 'service[systemd-timesyncd]', :delayed
 end
 
 service 'systemd-timesyncd' do
-  action [:enable, :start]
-  subscribes :restart, 'systemd_timesyncd[timesyncd]', :delayed
+  action :enable
   only_if { node['systemd']['enable_ntp'] }
 end

--- a/recipes/udevd.rb
+++ b/recipes/udevd.rb
@@ -43,5 +43,5 @@ systemd_service 'local-udevd-options' do
 end
 
 service 'systemd-udevd' do
-  action :nothing
+  action :enable
 end

--- a/spec/unit/recipes/hostname_spec.rb
+++ b/spec/unit/recipes/hostname_spec.rb
@@ -53,7 +53,7 @@ describe 'systemd::hostname' do
 
     it 'restarts the service' do
       file = chef_run.file('/etc/hostname')
-      expect(file).to notify('service[systemd-hostnamed]').to(:restart).immediately
+      expect(file).to notify('execute[set-hostname]').to(:run).immediately
     end
   end
 end

--- a/spec/unit/recipes/logind_spec.rb
+++ b/spec/unit/recipes/logind_spec.rb
@@ -13,9 +13,8 @@ describe 'systemd::logind' do
       )
     end
 
-    it 'enables/starts the service' do
+    it 'enables the service' do
       expect(chef_run).to enable_service('systemd-logind')
-      expect(chef_run).to start_service('systemd-logind')
     end
 
     it 'notifies service to restart' do

--- a/spec/unit/recipes/machined_spec.rb
+++ b/spec/unit/recipes/machined_spec.rb
@@ -7,9 +7,8 @@ describe 'systemd::machined' do
       runner.converge(described_recipe)
     end
 
-    it 'does not enable/start the service' do
+    it 'enables the service' do
       expect(chef_run).to enable_service('systemd-machined')
-      expect(chef_run).to start_service('systemd-machined')
     end
   end
 end

--- a/spec/unit/recipes/timesyncd_spec.rb
+++ b/spec/unit/recipes/timesyncd_spec.rb
@@ -14,9 +14,8 @@ describe 'systemd::timesyncd' do
       )
     end
 
-    it 'enables/starts the service' do
+    it 'enables the service' do
       expect(chef_run).to enable_service('systemd-timesyncd')
-      expect(chef_run).to start_service('systemd-timesyncd')
     end
 
     it 'notifies service to restart' do


### PR DESCRIPTION
- adds some links to the docs for the attributes
- add some explanatory comments to some of the spots where things get a little hairy
- use only the idempotent service actions for the static/on-demand utils (systemd-hostnamed, systemd-machined, etc) that only start on demand (bus activation), rather than running as daemons.
