### PR TITLE
add systemd-run resource/provider

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -13,7 +13,7 @@ platforms:
 
 suites:
   - name: reload
-    includes: centos-7.1
+    includes: centos-7.2
     run_list:
       - recipe[setup::daemon_reload]
   - name: units
@@ -39,7 +39,7 @@ suites:
       - recipe[systemd::timedated]
   - name: daemons-new
     includes:
-      - fedora-22
+      - fedora-23
     run_list:
       - recipe[setup::dnf]
       - recipe[systemd::journal_gatewayd]
@@ -72,10 +72,11 @@ suites:
             children-max: 10
   - name: utils-new
     includes:
-      - fedora-22
+      - fedora-23
     run_list:
       - recipe[systemd::vconsole]
       - recipe[systemd::binfmt]
       - recipe[setup::binfmt]
       - recipe[systemd::sysusers]
       - recipe[setup::sysuser]
+      - recipe[setup::run]

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -6,10 +6,10 @@ provisioner:
   name: chef_zero
 
 platforms:
-  - name: fedora-22
+  - name: fedora-23
   - name: ubuntu-15.04
   - name: debian-8.2
-  - name: centos-7.1
+  - name: centos-7.2
 
 suites:
   - name: reload

--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,7 @@ group :test do
   gem 'rake'
   gem 'chefspec'
   gem 'foodcritic'
-  gem 'rubocop', '~> 0.34.2'
+  gem 'rubocop'
 end
 
 group :integration do

--- a/README.md
+++ b/README.md
@@ -913,7 +913,7 @@ Also supports:
 
  - [drop-in](#common-drop-in)
 
-<a name="systemd-run"></a>**systemd\_sleep**
+<a name="systemd-run"></a>**systemd\_run**
 
 Resource for running (optionally) resource-constrained transient units.
 Think of it like an "execute" resource with cgroups.

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ A resource-driven [Chef][chef] cookbook for managing GNU/Linux systems via [syst
      - [systemd_bootchart](#systemd-bootchart)
      - [systemd_coredump](#systemd-coredump)
      - [systmd_sleep](#systemd-sleep)
+     - [systemd_run](#systemd-run)
    - [Miscellaneous](#misc-resources)
      - [systemd_system](#systemd-system)
      - [systemd_user](#systemd-user)
@@ -911,6 +912,25 @@ end
 Also supports:
 
  - [drop-in](#common-drop-in)
+
+<a name="systemd-run"></a>**systemd\_sleep**
+
+Resource for running (optionally) resource-constrained transient units.
+Think of it like an "execute" resource with cgroups.
+
+Example usage:
+
+```ruby
+systemd_run 'sshd-2222.service' do
+  command ''/usr/sbin/sshd -D -o Port=2222'
+  cpu_shares 1_024
+  nice 19
+  service_type 'simple'
+  kill_mode 'mixed'
+end
+```
+
+Supported attributes: see `Systemd::Run` in `libraries/systemd.rb`.
 
 <a name="misc-resources"></a>Miscellaneous Resources
 ----------------------------------------------------

--- a/README.md
+++ b/README.md
@@ -915,8 +915,8 @@ Also supports:
 
 <a name="systemd-run"></a>**systemd\_run**
 
-Resource for running (optionally) resource-constrained transient units.
-Think of it like an "execute" resource with cgroups.
+Resource for running (optionally) resource-constrained transient units
+with [systemd-run][run]. Think of it like an "execute" resource with cgroups.
 
 Example usage:
 
@@ -930,7 +930,124 @@ systemd_run 'sshd-2222.service' do
 end
 ```
 
-Supported attributes: see `Systemd::Run` in `libraries/systemd.rb`.
+|Attribute|Description|
+|---------|-----------|
+|unit|name of transient unit|
+|command|the command to run|
+|service_type|same as service unit Type directive|
+|setenv|`Hash` of env vars|
+|timer_property|`Hash` of timer properties|
+|delegate|see docs|
+|cpu_accounting|see docs|
+|cpu_quota|see docs|
+|cpu_shares|see docs|
+|block_io_accounting|see docs|
+|block_io_weight|see docs|
+|block_io_read_bandwidth|see docs|
+|block_io_write_bandwidth|see docs|
+|block_io_device_weight|see docs|
+|memory_accounting|see docs|
+|memory_limit|see docs|
+|device_policy|see docs|
+|device_allow|see docs|
+|tasks_accounting|see docs|
+|tasks_max|see docs|
+|user|see docs|
+|group|see docs|
+|syslog_identifier|see docs|
+|syslog_facility|see docs|
+|syslog_level|see docs|
+|nice|see docs|
+|tty_path|see docs|
+|working_directory|see docs|
+|root_directory|see docs|
+|standard_input|see docs|
+|standard_output|see docs|
+|standard_error|see docs|
+|ignore_sigpipe|see docs|
+|ttyv_hangup|see docs|
+|tty_reset|see docs|
+|private_tmp|see docs|
+|private_devices|see docs|
+|private_network|see docs|
+|no_new_privileges|see docs|
+|syslog_level_prefix|see docs|
+|utmp_identifier|see docs|
+|utmp_mode|see docs|
+|pam_name|see docs|
+|environment|see docs|
+|environment_file|see docs|
+|timer_slack_n_sec|see docs|
+|oom_score_adjust|see docs|
+|pass_environment|see docs|
+|read_write_directories|see docs|
+|read_only_directories|see docs|
+|inaccessible_directories|see docs|
+|protect_system|see docs|
+|protect_home|see docs|
+|runtime_directory|see docs|
+|limit_cpu|see docs|
+|limit_fsize|see docs|
+|limit_data|see docs|
+|limit_stack|see docs|
+|limit_core|see docs|
+|limit_rss|see docs|
+|limit_nofile|see docs|
+|limit_as|see docs|
+|limit_nproc|see docs|
+|limit_memlock|see docs|
+|limit_locks|see docs|
+|limit_sigpending|see docs|
+|limit_msgqueue|see docs|
+|limit_nice|see docs|
+|limit_rtprio|see docs|
+|limit_rttime|see docs|
+|kill_mode|see docs|
+|kill_signal|see docs|
+|send_sigkill|see docs|
+|what|see docs|
+|type|see docs|
+|options|see docs|
+|exec_start|see docs|
+|on_active_sec|see docs|
+|on_boot_sec|see docs|
+|on_startup_sec|see docs|
+|on_unit_active_sec|see docs|
+|on_unit_inactive_sec|see docs|
+|on_calendar|see docs|
+|accuracy_sec|see docs|
+|wake_system|see docs|
+|remain_after_elapse|see docs|
+|random_sec|see docs|
+|default_dependencies|see docs|
+|requires|see docs|
+|requires_overridable|see docs|
+|requisite|see docs|
+|requisite_overridable|see docs|
+|wants|see docs|
+|binds_to|see docs|
+|part_of|see docs|
+|conflicts|see docs|
+|before|see docs|
+|after|see docs|
+|on_failure|see docs|
+|propagates_reload_to|see docs|
+|reload_propagated_from|see docs|
+|description|see docs|
+|slice|see docs|
+|uid|see docs|
+|gid|see docs|
+|host|see docs|
+|machine|see docs|
+|scope|see docs|
+|remain_after_exit|see docs|
+|send_sighup|see docs|
+|no_block|see docs|
+|on_active|see docs|
+|on_boot|see docs|
+|on_startup|see docs|
+|on_unit_active|see docs|
+|on_unit_inactive|see docs|
 
 <a name="misc-resources"></a>Miscellaneous Resources
 ----------------------------------------------------
@@ -1592,6 +1709,7 @@ Cookbook-specific attributes that activate and control drop-in mode for units.
 [resource_control]: http://www.freedesktop.org/software/systemd/man/systemd.resource-control.html
 [rhel]: https://access.redhat.com/articles/754933
 [rules]: http://www.freedesktop.org/software/systemd/man/udev.html#Rules%20Files
+[run]: https://www.freedesktop.org/software/systemd/man/systemd-run.html
 [sd-reload]: https://www.youtube.com/watch?feature=player_detailpage&v=wVk-NWtiIZY#t=385
 [service]: http://www.freedesktop.org/software/systemd/man/systemd.service.html
 [sleep]: http://www.freedesktop.org/software/systemd/man/systemd-sleep.conf.html

--- a/libraries/binfmt.rb
+++ b/libraries/binfmt.rb
@@ -66,7 +66,7 @@ end
 
 class Chef::Provider
   class SystemdBinfmt < Chef::Provider::LWRPBase
-    DIR ||= '/etc/binfmt.d'
+    DIR ||= '/etc/binfmt.d'.freeze
 
     use_inline_resources
 

--- a/libraries/conf.rb
+++ b/libraries/conf.rb
@@ -33,7 +33,7 @@ class Chef::Resource
     # Child classes must implement. Used to
     # to locate appropriate helper modules.
     def conf_type
-      fail NotImplementedError
+      raise NotImplementedError
     end
 
     # Converts resource to a hash with configuration sections as hash
@@ -46,13 +46,13 @@ class Chef::Resource
       conf
     end
 
-    alias_method :to_h, :to_hash
+    alias to_h to_hash
 
     private
 
     # Converts a hash into resource attributes
     # See the Systemd module for more details.
-    def self.option_attributes(options = {})
+    private_class_method def self.option_attributes(options = {})
       options.each_pair do |name, config|
         attribute name.underscore.to_sym, config
       end

--- a/libraries/conf.rb
+++ b/libraries/conf.rb
@@ -21,10 +21,13 @@
 require 'chef/resource/lwrp_base'
 require 'chef/provider/lwrp_base'
 require_relative 'helpers'
+require_relative 'mixins'
 
 # Base class for resources configured with ini-formatted files
 class Chef::Resource
   class SystemdConf < Chef::Resource::LWRPBase
+    include Systemd::Mixin::DirectiveConversion
+
     resource_name :systemd_conf
 
     actions :create, :delete
@@ -47,40 +50,6 @@ class Chef::Resource
     end
 
     alias to_h to_hash
-
-    private
-
-    # Converts a hash into resource attributes
-    # See the Systemd module for more details.
-    private_class_method def self.option_attributes(options = {})
-      options.each_pair do |name, config|
-        attribute name.underscore.to_sym, config
-      end
-    end
-
-    # converts configuration hash (keys as directives, config as values)
-    # to an array of strings with camelized directive and stringified values
-    def options_config(opts = {})
-      opts.reject { |o, _| send(o.underscore.to_sym).nil? }.map do |name, _|
-        "#{name.camelize}=#{conf_string(send(name.underscore.to_sym))}"
-      end
-    end
-
-    # converts configuration options into the appropriate string format; it's
-    # critical to keep this in mind when choosing the `kind_of` key in the
-    # OPTIONS hash in the Systemd module for use with option_attributes.
-    def conf_string(obj)
-      case obj
-      when Hash
-        obj.map { |k, v| "\"#{k}=#{v}\"" }.join(' ')
-      when Array
-        obj.join(' ')
-      when TrueClass, FalseClass
-        obj ? 'yes' : 'no'
-      else
-        obj.to_s
-      end
-    end
   end
 end
 

--- a/libraries/handlers.rb
+++ b/libraries/handlers.rb
@@ -28,8 +28,10 @@ module SystemdHandlers
         r.is_a?(Chef::Resource::SystemdUnit) && r.auto_reload == false
       end
 
-      Chef::Resource::Execute.new('systemctl daemon-reload', run_context)
-        .run_action(:run) if reload_disabled.any?(&:updated_by_last_action?)
+      if reload_disabled.any?(&:updated_by_last_action?)
+        Chef::Resource::Execute.new('systemctl daemon-reload', run_context)
+                               .run_action(:run)
+      end
     end
   end
 end

--- a/libraries/matchers.rb
+++ b/libraries/matchers.rb
@@ -70,6 +70,7 @@ if defined?(ChefSpec)
     end
   end
 
+  ChefSpec.define_matcher(:systemd_modules)
   %w( load unload ).map(&:to_sym).each do |mod_action|
     define_method("#{mod_action}_systemd_modules") do |resource_name|
       ChefSpec::Matchers::ResourceMatcher.new(
@@ -78,6 +79,16 @@ if defined?(ChefSpec)
     end
   end
 
+  ChefSpec.define_matcher(:systemd_run)
+  %w( run stop ).map(&:to_sym).each do |run_action|
+    define_method("#{run_action}_systemd_run") do |resource_name|
+      ChefSpec::Matchers::ResourceMatcher.new(
+        :systemd_run, mod_action, resource_name
+      )
+    end
+  end
+
+  ChefSpec.define_matcher(:systemd_udev_rules)
   define_method('disable_systemd_udev_rules') do |resource_name|
     ChefSpec::Matchers::ResourceMatcher.new(
       :systemd_udev_rules, :disable, resource_name

--- a/libraries/mixins.rb
+++ b/libraries/mixins.rb
@@ -1,0 +1,44 @@
+
+module Systemd
+  module Mixin
+    module DirectiveConversion
+      def self.included(base)
+        base.extend ClassMethods
+      end
+
+      module ClassMethods
+        # Converts a hash into resource attributes
+        # See the Systemd module for more details.
+        def option_attributes(options = {})
+          options.each_pair do |name, config|
+            attribute name.underscore.to_sym, config
+          end
+        end
+      end
+
+      # converts configuration hash (keys as directives, config as values)
+      # to an array of strings with camelized directive and stringified values
+      def options_config(opts = {})
+        opts.reject { |o, _| send(o.underscore.to_sym).nil? }.map do |name, _|
+          "#{name.camelize}=#{conf_string(send(name.underscore.to_sym))}"
+        end
+      end
+
+      # converts configuration options into the appropriate string format; it's
+      # critical to keep this in mind when choosing the `kind_of` key in the
+      # OPTIONS hash in the Systemd module for use with option_attributes.
+      def conf_string(obj)
+        case obj
+        when Hash
+          obj.map { |k, v| "\"#{k}=#{v}\"" }.join(' ')
+        when Array
+          obj.join(' ')
+        when TrueClass, FalseClass
+          obj ? 'yes' : 'no'
+        else
+          obj.to_s
+        end
+      end
+    end
+  end
+end

--- a/libraries/networkd_link.rb
+++ b/libraries/networkd_link.rb
@@ -60,7 +60,7 @@ class Chef::Resource
       odd_opts(conf)
     end
 
-    alias_method :to_h, :to_hash
+    alias to_h to_hash
 
     private
 
@@ -87,7 +87,7 @@ end
 
 class Chef::Provider
   class SystemdNetworkdLink < Chef::Provider::LWRPBase
-    DIR ||= '/etc/systemd/network'
+    DIR ||= '/etc/systemd/network'.freeze
 
     use_inline_resources
 

--- a/libraries/run.rb
+++ b/libraries/run.rb
@@ -62,7 +62,6 @@ class Chef::Resource
     attribute :timer_property, kind_of: Hash, default: {}
 
     def cli_opts
-
     end
   end
 end

--- a/libraries/run.rb
+++ b/libraries/run.rb
@@ -139,9 +139,7 @@ class Chef::Provider
     action :stop do
       r = new_resource
 
-      stop = "systemctl stop #{r.unit}"
-
-      e = execute stop do
+      e = execute "systemctl stop #{r.unit}" do
         only_if { active?(r.unit) }
       end
 

--- a/libraries/run.rb
+++ b/libraries/run.rb
@@ -67,7 +67,7 @@ class Chef::Resource
     # rubocop: disable AbcSize
     # rubocop: disable MethodLength
     def cli_opts
-      cmd = ["--unit #{send(:unit)}"]
+      cmd = ["--unit=#{send(:unit)}"]
 
       cmd << "--service-type=#{send(:service_type)}" if send(:service_type)
 

--- a/libraries/run.rb
+++ b/libraries/run.rb
@@ -34,7 +34,7 @@ class Chef::Resource
     resource_name :systemd_run
     identity_attr :unit
 
-    actions :run
+    actions :run, :stop
     default_action :run
 
     def unit(arg = nil)
@@ -131,6 +131,18 @@ class Chef::Provider
 
       e = execute cmd do
         not_if { active?(r.unit) }
+      end
+
+      r.updated_by_last_action(e.updated_by_last_action?)
+    end
+
+    action :stop do
+      r = new_resource
+
+      stop = "systemctl stop #{r.unit}"
+
+      e = execute stop do
+        only_if { active?(r.unit) }
       end
 
       r.updated_by_last_action(e.updated_by_last_action?)

--- a/libraries/run.rb
+++ b/libraries/run.rb
@@ -59,7 +59,7 @@ class Chef::Resource
 end
 
 class Chef::Provider
-  class SystemdRun < Chef::Provider::Execute
+  class SystemdRun < Chef::Provider::LWRPBase
     use_inline_resources
 
     def whyrun_supported?

--- a/libraries/run.rb
+++ b/libraries/run.rb
@@ -58,7 +58,7 @@ class Chef::Resource
     end
 
     attribute :service_type, Systemd::Service::OPTIONS['Type']
-    attribute :setenv, Systemd::Exec::OPTIONS['Environment']
+    attribute :setenv, kind_of: Hash, default: {}
     attribute :timer_property, kind_of: Hash, default: {}
 
     option_attributes Systemd::Run::OPTIONS
@@ -88,7 +88,7 @@ class Chef::Resource
 
       cmd << options_config(Systemd::Run::OPTIONS).map { |o| "-p '#{o}'" }
 
-      cmd.flatten
+      cmd.flatten.join(' ')
     end
     # rubocop: enable AbcSize
     # rubocop: enable MethodLength
@@ -109,7 +109,7 @@ class Chef::Provider
       r = new_resource
 
       execute "systemd_run-#{r.name}" do
-        command "systemd-run #{r.cli_opts} '#{r.command}'"
+        command "systemd-run #{r.cli_opts} #{r.command}"
       end
     end
   end

--- a/libraries/run.rb
+++ b/libraries/run.rb
@@ -1,0 +1,76 @@
+#
+# Cookbook Name:: systemd
+# Library:: Chef::Resource::SystemdRun
+# Library:: Chef::Provider::SystemdRun
+#
+# Copyright 2015 The Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require 'chef/resource/lwrp_base'
+require 'chef/provider/lwrp_base'
+require 'mixlib/shellout'
+
+class Chef::Resource
+  class SystemdRun < Chef::Resource::LWRPBase
+    include Chef::Mixin::ParamsValidate
+
+    resource_name :systemd_run
+    identity_attr :command
+
+    actions :run
+    default_action :run
+
+    def command(arg = nil)
+      set_or_return(
+        :command, arg,
+        kind_of: String,
+        default: name
+      )
+    end
+
+    %w( scope no_block send_sighup pty ).map(&:to_sym).each do |a|
+      attribute a, kind_of: [TrueClass, FalseClass], default: false
+    end
+
+    option_attributes Systemd::Exec::OPTIONS
+    option_attributes Systemd::Kill::OPTIONS
+    option_attributes Systemd::ResourceControl::OPTIONS
+    option_attributes Systemd::Timer::OPTIONS
+
+    def cli_opts
+
+    end
+  end
+end
+
+class Chef::Provider
+  class SystemdRun < Chef::Provider::Execute
+    use_inline_resources
+
+    def whyrun_supported?
+      true
+    end
+
+    provides :systemd_run if defined?(provides)
+
+    action :run do
+      r = new_resource
+
+      execute "systemd_run-#{r.name}" do
+        command "systemd-run #{r.cli_opts} #{r.command}"
+      end
+    end
+  end
+end

--- a/libraries/run.rb
+++ b/libraries/run.rb
@@ -40,6 +40,9 @@ class Chef::Resource
       )
     end
 
+    attribute :unit, kind_of: String
+    attribute :slice, kind_of: String
+
     %w( scope no_block send_sighup pty ).map(&:to_sym).each do |a|
       attribute a, kind_of: [TrueClass, FalseClass], default: false
     end

--- a/libraries/sysctl.rb
+++ b/libraries/sysctl.rb
@@ -45,7 +45,7 @@ end
 
 class Chef::Provider
   class SystemdSysctl < Chef::Provider::LWRPBase
-    DIR ||= '/etc/sysctl.d'
+    DIR ||= '/etc/sysctl.d'.freeze
 
     use_inline_resources
 
@@ -72,7 +72,7 @@ class Chef::Provider
       r = new_resource
 
       current = Mixlib::ShellOut.new("sysctl -n #{r.name}")
-                .tap(&:run_command).stdout.chomp
+                                .tap(&:run_command).stdout.chomp
 
       e = execute "sysctl -e -w #{r.to_cli}" do
         not_if { current == Array(r.value).join(' ') }

--- a/libraries/systemd.rb
+++ b/libraries/systemd.rb
@@ -903,6 +903,6 @@ module Systemd
   module Run
     STRINGS ||= %w( unit description slice uid gid host machine )
     BOOLEANS ||= %w( scope remain_after_exit send_sighup no_block user system )
-    TIMER ||= Timer::OPTIONS.select { |o| o.match(/On\w+Sec/) }
+    ON_SECS ||= Timer::OPTIONS.select { |k, _| k.match(/^On\w+Sec$/) }
   end
 end

--- a/libraries/systemd.rb
+++ b/libraries/systemd.rb
@@ -31,7 +31,7 @@ module Systemd
       'Where' => {},
       'DirectoryMode' => { kind_of: [Integer, String] },
       'TimeoutIdleSec' => { kind_of: [Integer, String] }
-    }
+    }.freeze
   end
 
   module Bootchart
@@ -47,7 +47,7 @@ module Systemd
       'ScaleX' => { kind_of: Integer },
       'ScaleY' => { kind_of: Integer },
       'ControlGroup' => { kind_of: [TrueClass, FalseClass] }
-    }
+    }.freeze
   end
 
   module Coredump
@@ -62,7 +62,7 @@ module Systemd
       'JournalSizeMax' => { kind_of: Integer },
       'MaxUse' => {},
       'KeepFree' => {}
-    }
+    }.freeze
   end
 
   # rubocop: disable ModuleLength
@@ -153,7 +153,7 @@ module Systemd
       'LimitRTPRIO' => {},
       'LimitRTTIME' => {}
 
-    }
+    }.freeze
 
     OPTIONS ||= TRANSIENT_OPTIONS.merge(
       'SupplementaryGroups' => { kind_of: [String, Array] },
@@ -211,7 +211,7 @@ module Systemd
       'RequiredBy' => { kind_of: [String, Array] },
       'Also' => { kind_of: [String, Array] },
       'DefaultInstance' => {}
-    }
+    }.freeze
   end
 
   module Journald
@@ -246,7 +246,7 @@ module Systemd
       'MaxLevelConsole' => {},
       'MaxLevelWall' => {},
       'TTYPath' => {}
-    }
+    }.freeze
   end
 
   module JournalRemote
@@ -255,7 +255,7 @@ module Systemd
       'ServerKeyFile' => {},
       'ServerCertificateFile' => {},
       'TrustedCertificateFile' => {}
-    }
+    }.freeze
   end
 
   module Kill
@@ -267,7 +267,7 @@ module Systemd
       'KillSignal' => {},
       'SendSIGHUP' => { kind_of: [TrueClass, FalseClass] },
       'SendSIGKILL' => { kind_of: [TrueClass, FalseClass] }
-    }
+    }.freeze
 
     OPTIONS ||= TRANSIENT_OPTIONS
   end
@@ -288,7 +288,7 @@ module Systemd
       'LC_TELEPHONE' => {},
       'LC_MEASUREMENT' => {},
       'LC_IDENTIFICATION' => {}
-    }
+    }.freeze
   end
 
   module Logind
@@ -298,7 +298,7 @@ module Systemd
         ignore poweroff reboot halt kexec
         suspend hibernate hybrid-sleep lock
       )
-    }
+    }.freeze
 
     OPTIONS ||= {
       'NAutoVTs' => {
@@ -335,7 +335,7 @@ module Systemd
       'HoldoffTimeoutSec' => { kind_of: [String, Integer] },
       'RuntimeDirectorySize' => {},
       'RemoveIPC' => { kind_of: [TrueClass, FalseClass] }
-    }
+    }.freeze
   end
 
   module ResourceControl
@@ -367,7 +367,7 @@ module Systemd
                         end
                       }
                     }
-    }
+    }.freeze
 
     OPTIONS ||= TRANSIENT_OPTIONS.merge(
       'StartupCPUShares' => { kind_of: Integer },
@@ -381,7 +381,7 @@ module Systemd
       'What' => {},
       'Type' => {},
       'Options' => {}
-    }
+    }.freeze
 
     OPTIONS ||= TRANSIENT_OPTIONS
                 .merge(Systemd::ResourceControl::OPTIONS)
@@ -416,7 +416,7 @@ module Systemd
         'BitsPerSecond' => { kind_of: [String, Integer] },
         'Duplex' => { kind_of: String, equal_to: %w( half full ) },
         'WakeOnLan' => { kind_of: String, equal_to: %w( phy magic off ) }
-      }
+      }.freeze
     end
 
     module Match
@@ -443,7 +443,7 @@ module Systemd
             alpha arm arm-be arm64 arm64-be sh sh64 m86k tilegx cris
           )
         }
-      }
+      }.freeze
     end
 
     OPTIONS ||= Systemd::Networkd::Match::OPTIONS
@@ -458,7 +458,7 @@ module Systemd
         kind_of: [TrueClass, FalseClass, String],
         equal_to: [true, false, 'resolve']
       }
-    }
+    }.freeze
   end
 
   module Service
@@ -469,7 +469,7 @@ module Systemd
         equal_to: %w( simple forking oneshot dbus notify idle )
       },
       'RemainAfterExit' => { kind_of: [TrueClass, FalseClass] }
-    }
+    }.freeze
 
     OPTIONS ||= TRANSIENT_OPTIONS
                 .merge(Systemd::ResourceControl::OPTIONS)
@@ -546,7 +546,7 @@ module Systemd
       'SuspendState' => { kind_of: [String, Array] },
       'HibernateState' => { kind_of: [String, Array] },
       'HybridSleepState' => { kind_of: [String, Array] }
-    }
+    }.freeze
   end
 
   module Slice
@@ -701,7 +701,7 @@ module Systemd
       'DefaultLimitNICE' => {},
       'DefaultLimitRTPRIO' => {},
       'DefaultLimitRTTIME' => {}
-    }
+    }.freeze
   end
 
   module Path
@@ -716,19 +716,19 @@ module Systemd
         callbacks: {
           'is a valid unit ' => lambda do |spec|
             !spec.match(/\.path$/) &&
-            (Systemd::Helpers::UNITS | Systemd::Helpers::STUB_UNITS).any? do |u|
-              spec.match(/\.#{u}$/)
-            end
+              (Systemd::Helpers::UNITS | Systemd::Helpers::STUB_UNITS).any? do |u| # rubocop: disable LineLength
+                spec.match(/\.#{u}$/)
+              end
           end
         }
       },
       'MakeDirectory' => { kind_of: [TrueClass, FalseClass] },
       'DirectoryMode' => { kind_of: [String, Integer] }
-    }
+    }.freeze
   end
 
   module Target
-    OPTIONS ||= {}
+    OPTIONS ||= {}.freeze
   end
 
   module Timer
@@ -743,7 +743,7 @@ module Systemd
       'WakeSystem' => { kind_of: [TrueClass, FalseClass] },
       'RemainAfterElapse' => { kind_of: [TrueClass, FalseClass] },
       'RandomSec' => { kind_of: [String, Integer] }
-    }
+    }.freeze
 
     OPTIONS ||= TRANSIENT_OPTIONS.merge(
       'Unit' => {
@@ -765,7 +765,7 @@ module Systemd
     OPTIONS ||= {
       'NTP' => { kind_of: [String, Array] },
       'FallbackNTP' => { kind_of: [String, Array] }
-    }
+    }.freeze
   end
 
   # rubocop: disable ModuleLength
@@ -781,7 +781,7 @@ module Systemd
           end
         end
       }
-    }
+    }.freeze
 
     TRANSIENT_OPTIONS ||= {
       'Description' => {},
@@ -799,7 +799,7 @@ module Systemd
       'OnFailure' => UNIT_LIST,
       'PropagatesReloadTo' => UNIT_LIST,
       'ReloadPropagatedFrom' => UNIT_LIST
-    }
+    }.freeze
 
     OPTIONS ||= TRANSIENT_OPTIONS.merge(
       'Documentation' => { kind_of: [String, Array] },
@@ -919,20 +919,20 @@ module Systemd
       'FONT' => {},
       'FONT_MAP' => {},
       'FONT_UNIMAP' => {}
-    }
+    }.freeze
   end
 
   module Run
-    STRINGS ||= %w( unit description slice uid gid host machine )
+    STRINGS ||= %w( unit description slice uid gid host machine ).freeze
 
-    BOOLEANS ||= %w( scope remain_after_exit send_sighup no_block )
+    BOOLEANS ||= %w( scope remain_after_exit send_sighup no_block ).freeze
 
     ON_SECS ||= Systemd::Timer::TRANSIENT_OPTIONS
                 .keys
                 .select { |o| o.match(/On\w+Sec/) }
                 .map(&:underscore)
 
-    CLI_OPTS ||= (STRINGS << BOOLEANS << ON_SECS).flatten
+    CLI_OPTS ||= (STRINGS | BOOLEANS | ON_SECS).flatten
 
     OPTIONS ||= Systemd::ResourceControl::TRANSIENT_OPTIONS
                 .merge(Systemd::Exec::TRANSIENT_OPTIONS)

--- a/libraries/systemd.rb
+++ b/libraries/systemd.rb
@@ -930,6 +930,7 @@ module Systemd
     ON_SECS ||= Systemd::Timer::TRANSIENT_OPTIONS
                 .keys
                 .select { |o| o.match(/On\w+Sec/) }
+                .map { |o| o.gsub(/Sec$/, '') }
                 .map(&:underscore)
 
     CLI_OPTS ||= (STRINGS | BOOLEANS | ON_SECS).flatten

--- a/libraries/systemd.rb
+++ b/libraries/systemd.rb
@@ -923,7 +923,7 @@ module Systemd
   end
 
   module Run
-    STRINGS ||= %w( unit description slice uid gid host machine ).freeze
+    STRINGS ||= %w( description slice uid gid host machine ).freeze
 
     BOOLEANS ||= %w( scope remain_after_exit send_sighup no_block ).freeze
 

--- a/libraries/systemd.rb
+++ b/libraries/systemd.rb
@@ -67,35 +67,26 @@ module Systemd
 
   # rubocop: disable ModuleLength
   module Exec
-    OPTIONS ||= {
-      'WorkingDirectory' => {},
-      'RootDirectory' => {},
+    TRANSIENT_OPTIONS ||= {
       'User' => {},
       'Group' => {},
-      'SupplementaryGroups' => { kind_of: [String, Array] },
-      'Nice' => { kind_of: Integer, equal_to: -20.upto(19).to_a },
-      'OOMScoreAdjust' => {
-        kind_of: Integer,
-        equal_to: -1_000.upto(1_000).to_a
-      },
-      'IOSchedulingClass' => {
-        kind_of: [Integer, String],
-        equal_to: %w(none realtime best-effort idle).concat(0.upto(3).to_a)
-      },
-      'IOSchedulingPriority' => { kind_of: Integer, equal_to: 0.upto(7).to_a },
-      'CPUSchedulingPolicy' => {
+      'SyslogIdentifier' => {},
+      'SyslogFacility' => {
         kind_of: String,
-        equal_to: %w( other batch idle fifo rr )
+        equal_to: %w(
+          kern user mail daemon auth syslog lpr news
+          uucp cron authpriv ftp local0 local1 local2
+          local3 local4 local5 local6 local7
+        )
       },
-      'CPUSchedulingPriority' => {
-        kind_of: Integer,
-        equal_to: 1.upto(99).to_a
+      'SyslogLevel' => {
+        kind_of: String,
+        equal_to: %w( emerg alert crit debug warning notice info err )
       },
-      'CPUSchedulingResetOnFork' => { kind_of: [TrueClass, FalseClass] },
-      'CPUAffinity' => { kind_of: [String, Integer, Array] },
-      'UMask' => {},
-      'Environment' => { kind_of: Hash },
-      'EnvironmentFile' => {},
+      'Nice' => { kind_of: Integer, equal_to: -20.upto(19).to_a },
+      'TTYPath' => {},
+      'WorkingDirectory' => {},
+      'RootDirectory' => {},
       'StandardInput' => {
         kind_of: String,
         equal_to: %w( null tty tty-force tty-fail socket )
@@ -114,25 +105,37 @@ module Systemd
           syslog+console kmsg+console socket null tty
         )
       },
-      'TTYPath' => {},
-      'TTYReset' => { kind_of: [TrueClass, FalseClass] },
+      'IgnoreSIGPIPE' => { kind_of: [TrueClass, FalseClass] },
       'TTYVHangup' => { kind_of: [TrueClass, FalseClass] },
-      'TTYVTDisallocate' => { kind_of: [TrueClass, FalseClass] },
-      'SyslogIdentifier' => {},
-      'SyslogFacility' => {
-        kind_of: String,
-        equal_to: %w(
-          kern user mail daemon auth syslog lpr news
-          uucp cron authpriv ftp local0 local1 local2
-          local3 local4 local5 local6 local7
-        )
-      },
-      'SyslogLevel' => {
-        kind_of: String,
-        equal_to: %w( emerg alert crit debug warning notice info err )
-      },
+      'TTYReset' => { kind_of: [TrueClass, FalseClass] },
+      'PrivateTmp' => { kind_of: [TrueClass, FalseClass] },
+      'PrivateDevices' => { kind_of: [TrueClass, FalseClass] },
+      'PrivateNetwork' => { kind_of: [TrueClass, FalseClass] },
+      'NoNewPrivileges' => { kind_of: [TrueClass, FalseClass] },
       'SyslogLevelPrefix' => { kind_of: [TrueClass, FalseClass] },
+      'UtmpIdentifier' => {},
+      'UtmpMode' => { kind_of: String, equal_to: %w( init login user ) },
+      'PAMName' => {},
+      'Environment' => { kind_of: Hash },
+      'EnvironmentFile' => {},
       'TimerSlackNSec' => { kind_of: [Integer, String] },
+      'OOMScoreAdjust' => {
+        kind_of: Integer,
+        equal_to: -1_000.upto(1_000).to_a
+      },
+      'PassEnvironment' => { kind_of: Array },
+      'ReadWriteDirectories' => { kind_of: [String, Array] },
+      'ReadOnlyDirectories' => { kind_of: [String, Array] },
+      'InaccessibleDirectories' => { kind_of: [String, Array] },
+      'ProtectSystem' => {
+        kind_of: [TrueClass, FalseClass, String],
+        equal_to: [true, false, 'full']
+      },
+      'ProtectHome' => {
+        kind_of: [TrueClass, FalseClass, String],
+        equal_to: [true, false, 'read-only']
+      },
+      'RuntimeDirectory' => { kind_of: [String, Array] },
       'LimitCPU' => {},
       'LimitFSIZE' => {},
       'LimitDATA' => {},
@@ -148,8 +151,29 @@ module Systemd
       'LimitMSGQUEUE' => {},
       'LimitNICE' => {},
       'LimitRTPRIO' => {},
-      'LimitRTTIME' => {},
-      'PAMName' => {},
+      'LimitRTTIME' => {}
+
+    }
+
+    OPTIONS ||= TRANSIENT_OPTIONS.merge(
+      'SupplementaryGroups' => { kind_of: [String, Array] },
+      'IOSchedulingClass' => {
+        kind_of: [Integer, String],
+        equal_to: %w(none realtime best-effort idle).concat(0.upto(3).to_a)
+      },
+      'IOSchedulingPriority' => { kind_of: Integer, equal_to: 0.upto(7).to_a },
+      'CPUSchedulingPolicy' => {
+        kind_of: String,
+        equal_to: %w( other batch idle fifo rr )
+      },
+      'CPUSchedulingPriority' => {
+        kind_of: Integer,
+        equal_to: 1.upto(99).to_a
+      },
+      'CPUSchedulingResetOnFork' => { kind_of: [TrueClass, FalseClass] },
+      'CPUAffinity' => { kind_of: [String, Integer, Array] },
+      'UMask' => {},
+      'TTYVTDisallocate' => { kind_of: [TrueClass, FalseClass] },
       'CapabilityBoundingSet' => {},
       'SecureBits' => {
         kind_of: [String, Array],
@@ -163,39 +187,20 @@ module Systemd
         }
       },
       'Capabilities' => {},
-      'ReadWriteDirectories' => { kind_of: [String, Array] },
-      'ReadOnlyDirectories' => { kind_of: [String, Array] },
-      'InaccessibleDirectories' => { kind_of: [String, Array] },
-      'PrivateTmp' => { kind_of: [TrueClass, FalseClass] },
-      'PrivateDevices' => { kind_of: [TrueClass, FalseClass] },
-      'PrivateNetwork' => { kind_of: [TrueClass, FalseClass] },
-      'ProtectSystem' => {
-        kind_of: [TrueClass, FalseClass, String],
-        equal_to: [true, false, 'full']
-      },
-      'ProtectHome' => {
-        kind_of: [TrueClass, FalseClass, String],
-        equal_to: [true, false, 'read-only']
-      },
       'MountFlags' => {
         kind_of: String,
         equal_to: %w( shared slave private )
       },
-      'UtmpIdentifier' => {},
-      'UtmpMode' => { kind_of: String, equal_to: %w( init login user ) },
       'SELinuxContext' => {},
       'AppArmorProfile' => {},
       'SmackProcessLabel' => {},
-      'IgnoreSIGPIPE' => { kind_of: [TrueClass, FalseClass] },
-      'NoNewPrivileges' => { kind_of: [TrueClass, FalseClass] },
       'SystemCallFilter' => { kind_of: [String, Array] },
       'SystemCallErrorNumber' => {},
       'SystemCallArchitectures' => {},
       'RestrictAddressFamilies' => {},
       'Personality' => { kind_of: String, equal_to: %w( x86 x86-64 ) },
-      'RuntimeDirectory' => { kind_of: [String, Array] },
       'RuntimeDirectoryMode' => { kind_of: [String, Array] }
-    }
+    )
   end
   # rubocop: enable ModuleLength
 
@@ -254,7 +259,7 @@ module Systemd
   end
 
   module Kill
-    OPTIONS ||= {
+    TRANSIENT_OPTIONS ||= {
       'KillMode' => {
         kind_of: String,
         equal_to: %w( control-group process mixed none )
@@ -263,6 +268,8 @@ module Systemd
       'SendSIGHUP' => { kind_of: [TrueClass, FalseClass] },
       'SendSIGKILL' => { kind_of: [TrueClass, FalseClass] }
     }
+
+    OPTIONS ||= TRANSIENT_OPTIONS
   end
 
   module Locale
@@ -332,14 +339,22 @@ module Systemd
   end
 
   module ResourceControl
-    OPTIONS ||= {
+    TRANSIENT_OPTIONS ||= {
+      'Delegate' => { kind_of: [TrueClass, FalseClass] },
       'CPUAccounting' => { kind_of: [TrueClass, FalseClass] },
-      'CPUShares' => { kind_of: Integer },
-      'StartupCPUShares' => { kind_of: Integer },
       'CPUQuota' => {},
+      'CPUShares' => { kind_of: Integer },
+      'BlockIOAccounting' => { kind_of: [TrueClass, FalseClass] },
+      'BlockIOWeight' => { kind_of: Integer, equal_to: 10.upto(1_000) },
+      'BlockIOReadBandwidth' => {},
+      'BlockIOWriteBandwidth' => {},
+      'BlockIODeviceWeight' => {},
       'MemoryAccounting' => { kind_of: [TrueClass, FalseClass] },
       'MemoryLimit' => {},
+      'DevicePolicy' => { kind_of: String, equal_to: %w( strict closed auto ) },
+      'DeviceAllow' => {},
       'TasksAccounting' => { kind_of: [TrueClass, FalseClass] },
+      'Slice' => {},
       'TasksMax' => { kind_of: [Integer, String],
                       callbacks: {
                         'is a valid symbol' =>
@@ -351,29 +366,28 @@ module Systemd
                           end
                         end
                       }
-                    },
-      'BlockIOAccounting' => { kind_of: [TrueClass, FalseClass] },
-      'BlockIOWeight' => { kind_of: Integer, equal_to: 10.upto(1_000) },
-      'StartupBlockIOWeight' => { kind_of: Integer, equal_to: 10.upto(1_000) },
-      'BlockIODeviceWeight' => {},
-      'BlockIOReadBandwidth' => {},
-      'BlockIOWriteBandwidth' => {},
-      'DeviceAllow' => {},
-      'DevicePolicy' => { kind_of: String, equal_to: %w( strict closed auto ) },
-      'Slice' => {},
-      'NetClass' => {},
-      'Delegate' => { kind_of: [TrueClass, FalseClass] }
+                    }
     }
+
+    OPTIONS ||= TRANSIENT_OPTIONS.merge(
+      'StartupCPUShares' => { kind_of: Integer },
+      'StartupBlockIOWeight' => { kind_of: Integer, equal_to: 10.upto(1_000) },
+      'NetClass' => {}
+    )
   end
 
   module Mount
-    OPTIONS ||= Systemd::ResourceControl::OPTIONS
+    TRANSIENT_OPTIONS ||= {
+      'What' => {},
+      'Type' => {},
+      'Options' => {}
+    }
+
+    OPTIONS ||= TRANSIENT_OPTIONS
+                .merge(Systemd::ResourceControl::OPTIONS)
                 .merge(Systemd::Exec::OPTIONS)
                 .merge(Systemd::Kill::OPTIONS)
-                .merge('What' => {},
-                       'Where' => {},
-                       'Type' => {},
-                       'Options' => {},
+                .merge('Where' => {},
                        'SloppyOptions' => { kind_of: [TrueClass, FalseClass] },
                        'DirectoryMode' => { kind_of: [String, Integer] },
                        'TimeoutSec' => { kind_of: [String, Integer] })
@@ -448,23 +462,25 @@ module Systemd
   end
 
   module Service
-    OPTIONS ||= Systemd::ResourceControl::OPTIONS
+    TRANSIENT_OPTIONS ||= {
+      'ExecStart' => {},
+      'Type' => {
+        kind_of: String,
+        equal_to: %w( simple forking oneshot dbus notify idle )
+      },
+      'RemainAfterExit' => { kind_of: [TrueClass, FalseClass] }
+    }
+
+    OPTIONS ||= TRANSIENT_OPTIONS
+                .merge(Systemd::ResourceControl::OPTIONS)
                 .merge(Systemd::Exec::OPTIONS)
                 .merge(Systemd::Kill::OPTIONS)
-                .merge('Type' => {
-                         kind_of: String,
-                         equal_to: %w( simple forking oneshot dbus notify idle )
-                       },
-                       'RemainAfterExit' => {
-                         kind_of: [TrueClass, FalseClass]
-                       },
-                       'GuessMainPID' => {
+                .merge('GuessMainPID' => {
                          kind_of: [TrueClass, FalseClass]
                        },
                        'PIDFile' => {},
                        'BusName' => {},
                        'BusPolicy' => {},
-                       'ExecStart' => {},
                        'ExecStartPre' => {},
                        'ExecStartPost' => {},
                        'ExecReload' => {},
@@ -716,7 +732,7 @@ module Systemd
   end
 
   module Timer
-    OPTIONS ||= {
+    TRANSIENT_OPTIONS ||= {
       'OnActiveSec' => { kind_of: [String, Integer] },
       'OnBootSec' => { kind_of: [String, Integer] },
       'OnStartupSec' => { kind_of: [String, Integer] },
@@ -724,7 +740,12 @@ module Systemd
       'OnUnitInactiveSec' => { kind_of: [String, Integer] },
       'OnCalendar' => {},
       'AccuracySec' => { kind_of: [String, Integer] },
-      'RandomSec' => { kind_of: [String, Integer] },
+      'WakeSystem' => { kind_of: [TrueClass, FalseClass] },
+      'RemainAfterElapse' => { kind_of: [TrueClass, FalseClass] },
+      'RandomSec' => { kind_of: [String, Integer] }
+    }
+
+    OPTIONS ||= TRANSIENT_OPTIONS.merge(
       'Unit' => {
         kind_of: String,
         callbacks: {
@@ -736,10 +757,8 @@ module Systemd
           end
         }
       },
-      'Persistent' => { kind_of: [TrueClass, FalseClass] },
-      'WakeSystem' => { kind_of: [TrueClass, FalseClass] },
-      'RemainAfterElapse' => { kind_of: [TrueClass, FalseClass] }
-    }
+      'Persistent' => { kind_of: [TrueClass, FalseClass] }
+    )
   end
 
   module Timesyncd
@@ -764,9 +783,9 @@ module Systemd
       }
     }
 
-    OPTIONS ||= {
+    TRANSIENT_OPTIONS ||= {
       'Description' => {},
-      'Documentation' => { kind_of: [String, Array] },
+      'DefaultDependencies' => { kind_of: [TrueClass, FalseClass] },
       'Requires' => UNIT_LIST,
       'RequiresOverridable' => UNIT_LIST,
       'Requisite' => UNIT_LIST,
@@ -779,7 +798,11 @@ module Systemd
       'After' => UNIT_LIST,
       'OnFailure' => UNIT_LIST,
       'PropagatesReloadTo' => UNIT_LIST,
-      'ReloadPropagatedFrom' => UNIT_LIST,
+      'ReloadPropagatedFrom' => UNIT_LIST
+    }
+
+    OPTIONS ||= TRANSIENT_OPTIONS.merge(
+      'Documentation' => { kind_of: [String, Array] },
       'JoinsNamespaceOf' => UNIT_LIST,
       'RequiresMountsFor' => { kind_of: [String, Array] },
       'OnFailureJobMode' => {
@@ -795,7 +818,6 @@ module Systemd
       'RefuseManualStart' => { kind_of: [TrueClass, FalseClass] },
       'RefuseManualStop' => { kind_of: [TrueClass, FalseClass] },
       'AllowIsolate' => { kind_of: [TrueClass, FalseClass] },
-      'DefaultDependencies' => { kind_of: [TrueClass, FalseClass] },
       'JobTimeoutSec' => { kind_of: [String, Integer] },
       'JobTimeoutAction' => {
         kind_of: String,
@@ -882,7 +904,7 @@ module Systemd
       'AssertFileNotEmpty' => {},
       'AssertFileIsExecutable' => {},
       'SourcePath' => {}
-    }
+    )
   end
   # rubocop: enable ModuleLength
 
@@ -902,7 +924,23 @@ module Systemd
 
   module Run
     STRINGS ||= %w( unit description slice uid gid host machine )
-    BOOLEANS ||= %w( scope remain_after_exit send_sighup no_block user system )
-    ON_SECS ||= Timer::OPTIONS.select { |k, _| k.match(/^On\w+Sec$/) }
+
+    BOOLEANS ||= %w( scope remain_after_exit send_sighup no_block )
+
+    ON_SECS ||= Systemd::Timer::TRANSIENT_OPTIONS
+                .keys
+                .select { |o| o.match(/On\w+Sec/) }
+                .map(&:underscore)
+
+    CLI_OPTS ||= (STRINGS << BOOLEANS << ON_SECS).flatten
+
+    OPTIONS ||= Systemd::ResourceControl::TRANSIENT_OPTIONS
+                .merge(Systemd::Exec::TRANSIENT_OPTIONS)
+                .merge(Systemd::Kill::TRANSIENT_OPTIONS)
+                .merge(Systemd::Mount::TRANSIENT_OPTIONS)
+                .merge(Systemd::Service::TRANSIENT_OPTIONS)
+                .merge(Systemd::Timer::TRANSIENT_OPTIONS)
+                .merge(Systemd::Unit::TRANSIENT_OPTIONS)
+                .delete_if { |k, _| CLI_OPTS.include?(k.underscore) }
   end
 end

--- a/libraries/systemd.rb
+++ b/libraries/systemd.rb
@@ -899,4 +899,10 @@ module Systemd
       'FONT_UNIMAP' => {}
     }
   end
+
+  module Run
+    STRINGS ||= %w( unit description slice uid gid host machine )
+    BOOLEANS ||= %w( scope remain_after_exit send_sighup no_block user system )
+    TIMER ||= Timer::OPTIONS.select { |o| o.match(/On\w+Sec/) }
+  end
 end

--- a/libraries/sysuser.rb
+++ b/libraries/sysuser.rb
@@ -52,7 +52,7 @@ end
 
 class Chef::Provider
   class SystemdSysuser < Chef::Provider::LWRPBase
-    DIR ||= '/etc/sysusers.d'
+    DIR ||= '/etc/sysusers.d'.freeze
 
     use_inline_resources
 

--- a/libraries/tmpfile.rb
+++ b/libraries/tmpfile.rb
@@ -47,7 +47,7 @@ end
 
 class Chef::Provider
   class SystemdTmpfile < Chef::Provider::LWRPBase
-    DIR ||= '/etc/tmpfiles.d'
+    DIR ||= '/etc/tmpfiles.d'.freeze
 
     use_inline_resources
 

--- a/libraries/udev_rules.rb
+++ b/libraries/udev_rules.rb
@@ -25,13 +25,13 @@ class Chef::Resource
   # resource for managing udev rules
   # http://www.freedesktop.org/software/systemd/man/udev.html
   class SystemdUdevRules < Chef::Resource::LWRPBase
-    VALID_UDEV_OPERATORS ||= %w( == != = += -= := )
-    VALID_RULE_KEYS ||= %w( key operator value )
+    VALID_UDEV_OPERATORS ||= %w( == != = += -= := ).freeze
+    VALID_RULE_KEYS ||= %w( key operator value ).freeze
     VALID_UDEV_KEYS ||= %w(
       ACTION DEVPATH KERNEL NAME SUBSYSTEM DRIVER OPTIONS
       SYMLINK ATTR SYSCTL ENV TEST PROGRAM RESULT IMPORT
       NAME OWNER GROUP MODE SECLABEL RUN LABEL GOTO TAG
-    )
+    ).freeze
 
     resource_name :systemd_udev_rules
 
@@ -43,9 +43,9 @@ class Chef::Resource
         specs.is_a?(Array) && specs.all? do |spec|
           spec.is_a?(Array) && spec.all? do |rule|
             rule.length == 3 &&
-              rule.keys.all? { |k| VALID_RULE_KEYS.include? k } &&
-              VALID_UDEV_KEYS.any? { |k| rule['key'].start_with? k } &&
-              VALID_UDEV_OPERATORS.include?(rule['operator'])
+            rule.keys.all? { |k| VALID_RULE_KEYS.include? k } &&
+            VALID_UDEV_KEYS.any? { |k| rule['key'].start_with? k } &&
+            VALID_UDEV_OPERATORS.include?(rule['operator'])
           end
         end
       end
@@ -63,7 +63,7 @@ end
 
 class Chef::Provider
   class SystemdUdevRules < Chef::Provider::LWRPBase
-    DIR ||= '/etc/udev/rules.d'
+    DIR ||= '/etc/udev/rules.d'.freeze
 
     use_inline_resources
 

--- a/libraries/unit.rb
+++ b/libraries/unit.rb
@@ -48,8 +48,8 @@ class Chef::Resource
     def action(arg = nil)
       if drop_in
         @allowed_actions = %w( create delete set_properties ).map(&:to_sym)
-      else
-        @allowed_actions << :set_default if conf_type == :target
+      elsif conf_type == :target
+        @allowed_actions << :set_default
       end
 
       super
@@ -96,7 +96,7 @@ class Chef::Resource
       conf
     end
 
-    alias_method :to_h, :to_hash
+    alias to_h to_hash
 
     private
 

--- a/libraries/units.rb
+++ b/libraries/units.rb
@@ -177,7 +177,7 @@ class Chef::Provider
       r = new_resource
 
       current_default = Mixlib::ShellOut.new('systemctl get-default')
-                        .tap(&:run_command).stdout.chomp
+                                        .tap(&:run_command).stdout.chomp
 
       target_default = "#{r.name}.#{r.conf_type}"
 

--- a/spec/unit/resource_systemd_run_spec.rb
+++ b/spec/unit/resource_systemd_run_spec.rb
@@ -1,0 +1,27 @@
+require 'spec_helper'
+
+describe Chef::Resource::SystemdRun do
+  let(:svc_run) do
+    Chef::Resource::SystemdRun.new("env").tap do |r|
+      r.service_type 'simple'
+      r.setenv({ 'FOO' => 0, 'BAR' => 1 })
+      r.description 'transient'
+      r.cpu_shares 1_024
+      r.nice 19
+      r.on_active 15
+      r.kill_mode 'mixed'
+    end
+  end
+
+  let(:svc_opts) do
+    [
+      "--service-type=simple", "--description='transient'",
+      "--on-active='15'", "--setenv=FOO=0", "--setenv=BAR=1",
+      "-p 'CPUShares=1024'", "-p 'Nice=19'", "-p 'KillMode=mixed'"
+    ]
+  end
+
+  it 'generates proper service cli options' do
+    expect(svc_run.cli_opts).to eq svc_opts
+  end
+end

--- a/spec/unit/resource_systemd_run_spec.rb
+++ b/spec/unit/resource_systemd_run_spec.rb
@@ -2,7 +2,8 @@ require 'spec_helper'
 
 describe Chef::Resource::SystemdRun do
   let(:svc_run) do
-    Chef::Resource::SystemdRun.new("env").tap do |r|
+    Chef::Resource::SystemdRun.new("transient-env.service").tap do |r|
+      r.command 'env'
       r.service_type 'simple'
       r.setenv({ 'FOO' => 0, 'BAR' => 1 })
       r.description 'transient'
@@ -15,9 +16,10 @@ describe Chef::Resource::SystemdRun do
 
   let(:svc_opts) do
     [
-      "--service-type=simple", "--description='transient'",
-      "--on-active='15'", "--setenv=FOO=0", "--setenv=BAR=1",
-      "-p 'CPUShares=1024'", "-p 'Nice=19'", "-p 'KillMode=mixed'"
+      "--unit=transient-env.service", "--service-type=simple",
+      "--description='transient'","--on-active='15'", "--setenv=FOO=0",
+      "--setenv=BAR=1", "-p 'CPUShares=1024'", "-p 'Nice=19'",
+      "-p 'KillMode=mixed'"
     ].join(' ')
   end
 

--- a/spec/unit/resource_systemd_run_spec.rb
+++ b/spec/unit/resource_systemd_run_spec.rb
@@ -18,7 +18,7 @@ describe Chef::Resource::SystemdRun do
       "--service-type=simple", "--description='transient'",
       "--on-active='15'", "--setenv=FOO=0", "--setenv=BAR=1",
       "-p 'CPUShares=1024'", "-p 'Nice=19'", "-p 'KillMode=mixed'"
-    ]
+    ].join(' ')
   end
 
   it 'generates proper service cli options' do

--- a/spec/unit/resource_systemd_service_spec.rb
+++ b/spec/unit/resource_systemd_service_spec.rb
@@ -15,7 +15,7 @@ describe Chef::Resource::SystemdService do
     {
       :unit=>["Description=test unit", "Documentation=http://example.com"],
       :install=>["WantedBy=multi-user.target"],
-      :service=>["MemoryLimit=1G", "ExecStart=/usr/bin/true"]
+      :service=>["ExecStart=/usr/bin/true", "MemoryLimit=1G"]
     }
   end
 

--- a/spec/unit/resource_systemd_unit_spec.rb
+++ b/spec/unit/resource_systemd_unit_spec.rb
@@ -15,7 +15,7 @@ describe Chef::Resource::SystemdUnit do
     {
       :unit=>["Description=test unit", "Documentation=http://example.com"],
       :install=>["WantedBy=multi-user.target"],
-      :service=>["MemoryLimit=1G", "ExecStart=/usr/bin/true"]
+      :service=>["ExecStart=/usr/bin/true", "MemoryLimit=1G"]
     }
   end
 

--- a/test/fixtures/cookbooks/setup/recipes/run.rb
+++ b/test/fixtures/cookbooks/setup/recipes/run.rb
@@ -1,0 +1,17 @@
+
+systemd_run 'test-run' do
+  command [
+    '/usr/sbin/sshd -D',
+    '-o UseDNS=no',
+    '-o UsePAM=no',
+    '-o PasswordAuthentication=yes',
+    '-o UsePrivilegeSeparation=no',
+    '-o PidFile=/tmp/sshd.pid',
+    '-o Port=2222'
+  ].join(' ')
+  unit 'sshd-2222.service'
+  cpu_shares 1_024
+  nice 19
+  description 'sshd transient unit'
+  service_type 'simple'
+end

--- a/test/fixtures/cookbooks/setup/recipes/run.rb
+++ b/test/fixtures/cookbooks/setup/recipes/run.rb
@@ -1,5 +1,5 @@
 
-systemd_run 'test-run' do
+systemd_run 'sshd-2222.service' do
   command [
     '/usr/sbin/sshd -D',
     '-o UseDNS=no',
@@ -9,9 +9,9 @@ systemd_run 'test-run' do
     '-o PidFile=/tmp/sshd.pid',
     '-o Port=2222'
   ].join(' ')
-  unit 'sshd-2222.service'
   cpu_shares 1_024
   nice 19
   description 'sshd transient unit'
   service_type 'simple'
+  kill_mode 'mixed'
 end

--- a/test/integration/utils-new/serverspec/run_spec.rb
+++ b/test/integration/utils-new/serverspec/run_spec.rb
@@ -1,0 +1,11 @@
+require 'spec_helper'
+
+describe 'SystemdRun' do
+  describe port(2222) do
+    it { should be_listening }
+  end
+
+  describe service('sshd-2222') do
+    it { should be_running }
+  end
+end


### PR DESCRIPTION
adds a systemd-run wrapper for creating transient units:
- [x] support systemd-run CLI args as attributes
- [x] support transient unit properties as attributes
- [x] support idempotency (avoid re-execution if transient unit from previous converge is still active)
