### PR TITLE
move namespace

### DIFF
--- a/libraries/binfmt.rb
+++ b/libraries/binfmt.rb
@@ -23,8 +23,8 @@ require 'chef/provider/lwrp_base'
 
 # Configure additional binary formats for executables at boot
 # http://www.freedesktop.org/software/systemd/man/binfmt.d.html
-class Chef::Resource
-  class SystemdBinfmt < Chef::Resource::LWRPBase
+class ChefSystemdCookbook
+  class BinfmtResource < Chef::Resource::LWRPBase
     resource_name :systemd_binfmt
 
     actions :create, :delete
@@ -62,10 +62,8 @@ class Chef::Resource
       ":#{str.join(':')}"
     end
   end
-end
 
-class Chef::Provider
-  class SystemdBinfmt < Chef::Provider::LWRPBase
+  class BinfmtProvider < Chef::Provider::LWRPBase
     DIR ||= '/etc/binfmt.d'.freeze
 
     use_inline_resources

--- a/libraries/conf.rb
+++ b/libraries/conf.rb
@@ -24,8 +24,8 @@ require_relative 'helpers'
 require_relative 'mixins'
 
 # Base class for resources configured with ini-formatted files
-class Chef::Resource
-  class SystemdConf < Chef::Resource::LWRPBase
+class ChefSystemdCookbook
+  class ConfResource < Chef::Resource::LWRPBase
     include Systemd::Mixin::DirectiveConversion
 
     resource_name :systemd_conf
@@ -51,10 +51,8 @@ class Chef::Resource
 
     alias to_h to_hash
   end
-end
 
-class Chef::Provider
-  class SystemdConf < Chef::Provider::LWRPBase
+  class ConfProvider < Chef::Provider::LWRPBase
     use_inline_resources
 
     def whyrun_supported?
@@ -77,7 +75,9 @@ class Chef::Provider
         execute "#{r.name}.#{r.conf_type}-systemd-reload" do
           command 'systemctl daemon-reload'
           action :nothing
-          only_if { r.is_a?(Chef::Resource::SystemdUnit) && r.auto_reload }
+          only_if do
+            r.is_a?(ChefSystemdCookbook::UnitResource) && r.auto_reload
+          end
           subscribes :run, "file[#{conf_path}]", :immediately
         end
 

--- a/libraries/daemon.rb
+++ b/libraries/daemon.rb
@@ -22,18 +22,16 @@ require_relative 'helpers'
 require_relative 'conf'
 
 # base class for daemon resources
-class Chef::Resource
-  class SystemdDaemon < Chef::Resource::SystemdConf
+class ChefSystemdCookbook
+  class DaemonResource < ChefSystemdCookbook::ConfResource
     resource_name :systemd_daemon
 
     attribute :drop_in, kind_of: [TrueClass, FalseClass], default: true
     attribute :conf_type, kind_of: Symbol, required: true,
                           equal_to: Systemd::Helpers::DAEMONS
   end
-end
 
-class Chef::Provider
-  class SystemdDaemon < Chef::Provider::SystemdConf
+  class DaemonProvider < ChefSystemdCookbook::ConfProvider
     provides :systemd_daemon if defined?(provides)
     Systemd::Helpers::DAEMONS.each do |daemon|
       provides "systemd_#{daemon}".to_sym if defined?(provides)

--- a/libraries/daemons.rb
+++ b/libraries/daemons.rb
@@ -26,10 +26,10 @@ require_relative 'systemd'
 require_relative 'daemon'
 
 # TODO: deduplicate the boilerplate
-class Chef::Resource
+class ChefSystemdCookbook
   # resource for configuring systemd-journald
   # http://www.freedesktop.org/software/systemd/man/systemd-journald.service.html
-  class SystemdJournald < Chef::Resource::SystemdDaemon
+  class JournaldResource < ChefSystemdCookbook::DaemonResource
     resource_name :systemd_journald
 
     def conf_type(_ = nil)
@@ -45,7 +45,7 @@ class Chef::Resource
 
   # resource for configuring systemd-logind
   # http://www.freedesktop.org/software/systemd/man/systemd-logind.service.html
-  class SystemdLogind < Chef::Resource::SystemdDaemon
+  class LogindResource < ChefSystemdCookbook::DaemonResource
     resource_name :systemd_logind
 
     def conf_type(_ = nil)
@@ -61,7 +61,7 @@ class Chef::Resource
 
   # resource for configuring systemd-resolved
   # http://www.freedesktop.org/software/systemd/man/systemd-resolved.service.html
-  class SystemdResolved < Chef::Resource::SystemdDaemon
+  class ResolvedResource < ChefSystemdCookbook::DaemonResource
     resource_name :systemd_resolved
 
     def conf_type(_ = nil)
@@ -77,7 +77,7 @@ class Chef::Resource
 
   # resource for configuring systemd-timesyncd
   # http://www.freedesktop.org/software/systemd/man/systemd-timesyncd.service.html
-  class SystemdTimesyncd < Chef::Resource::SystemdDaemon
+  class TimesyncdResource < ChefSystemdCookbook::DaemonResource
     resource_name :systemd_timesyncd
 
     def conf_type(_ = nil)

--- a/libraries/handlers.rb
+++ b/libraries/handlers.rb
@@ -25,7 +25,7 @@ module SystemdHandlers
   class DaemonReload
     def conditionally_reload(run_context)
       reload_disabled = run_context.resource_collection.select do |r|
-        r.is_a?(Chef::Resource::SystemdUnit) && r.auto_reload == false
+        r.is_a?(ChefSystemdCookbook::UnitResource) && r.auto_reload == false
       end
 
       if reload_disabled.any?(&:updated_by_last_action?)

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -58,7 +58,7 @@ module Systemd
 
     # path for drop-in configuration of systemd resources
     def conf_drop_in_root(conf)
-      if conf.is_a?(Chef::Resource::SystemdUnit)
+      if conf.is_a?(ChefSystemdCookbook::UnitResource)
         ::File.join(
           unit_conf_root(conf),
           "#{conf.override}.#{conf.conf_type}.d"
@@ -72,7 +72,7 @@ module Systemd
     def conf_path(conf)
       if conf.drop_in
         ::File.join(conf_drop_in_root(conf), "#{conf.name}.conf")
-      elsif conf.is_a?(Chef::Resource::SystemdUnit)
+      elsif conf.is_a?(ChefSystemdCookbook::UnitResource)
         ::File.join(unit_conf_root(conf), "#{conf.name}.#{conf.conf_type}")
       else
         ::File.join(local_conf_root, "#{conf.conf_type}.conf")

--- a/libraries/modules.rb
+++ b/libraries/modules.rb
@@ -22,11 +22,11 @@ require 'chef/resource/lwrp_base'
 require 'chef/provider/lwrp_base'
 require_relative 'helpers'
 
-class Chef::Resource
+class ChefSystemdCookbook
   # manage system modules
   # http://www.freedesktop.org/software/systemd/man/modules-load.d.html
   # http://linux.die.net/man/5/modprobe.d
-  class SystemdModules < Chef::Resource::LWRPBase
+  class ModulesResource < Chef::Resource::LWRPBase
     resource_name :systemd_modules
 
     actions :create, :delete, :load, :unload
@@ -35,10 +35,8 @@ class Chef::Resource
     attribute :blacklist, kind_of: [TrueClass, FalseClass], default: false
     attribute :modules, kind_of: Array, default: %w(), required: true
   end
-end
 
-class Chef::Provider
-  class SystemdModules < Chef::Provider::LWRPBase
+  class ModulesProvider < Chef::Provider::LWRPBase
     use_inline_resources
 
     def whyrun_supported?

--- a/libraries/networkd_link.rb
+++ b/libraries/networkd_link.rb
@@ -23,10 +23,10 @@ require 'chef/provider/lwrp_base'
 require_relative 'systemd'
 require_relative 'helpers'
 
-class Chef::Resource
+class ChefSystemdCookbook
   # resource for systemd network device configuration
   # http://www.freedesktop.org/software/systemd/man/systemd.link.html
-  class SystemdNetworkdLink < Chef::Resource::LWRPBase
+  class NetworkdLinkResource < Chef::Resource::LWRPBase
     resource_name :systemd_networkd_link
 
     actions :create, :delete
@@ -83,10 +83,8 @@ class Chef::Resource
     end
     # rubocop: enable AbcSize
   end
-end
 
-class Chef::Provider
-  class SystemdNetworkdLink < Chef::Provider::LWRPBase
+  class NetworkdLinkProvider < Chef::Provider::LWRPBase
     DIR ||= '/etc/systemd/network'.freeze
 
     use_inline_resources

--- a/libraries/run.rb
+++ b/libraries/run.rb
@@ -26,8 +26,8 @@ require_relative 'systemd'
 require_relative 'helpers'
 require_relative 'mixins'
 
-class Chef::Resource
-  class SystemdRun < Chef::Resource::LWRPBase
+class ChefSystemdCookbook
+  class SystemdRunResource < Chef::Resource::LWRPBase
     include Chef::Mixin::ParamsValidate
     include Systemd::Mixin::DirectiveConversion
 
@@ -94,10 +94,8 @@ class Chef::Resource
     # rubocop: enable AbcSize
     # rubocop: enable MethodLength
   end
-end
 
-class Chef::Provider
-  class SystemdRun < Chef::Provider::LWRPBase
+  class SystemdRunProvider < Chef::Provider::LWRPBase
     use_inline_resources
 
     def whyrun_supported?

--- a/libraries/sysctl.rb
+++ b/libraries/sysctl.rb
@@ -22,10 +22,10 @@ require 'chef/resource/lwrp_base'
 require 'chef/provider/lwrp_base'
 require 'mixlib/shellout'
 
-class Chef::Resource
+class ChefSystemdCookbook
   # resource for configuring kernel parameters
   # http://man7.org/linux/man-pages/man5/sysctl.d.5.html
-  class SystemdSysctl < Chef::Resource::LWRPBase
+  class SysctlResource < Chef::Resource::LWRPBase
     resource_name :systemd_sysctl
 
     actions :create, :delete, :apply
@@ -41,10 +41,8 @@ class Chef::Resource
       "#{name}='#{Array(value).join(' ')}'"
     end
   end
-end
 
-class Chef::Provider
-  class SystemdSysctl < Chef::Provider::LWRPBase
+  class SysctlProvider < Chef::Provider::LWRPBase
     DIR ||= '/etc/sysctl.d'.freeze
 
     use_inline_resources

--- a/libraries/sysuser.rb
+++ b/libraries/sysuser.rb
@@ -21,10 +21,10 @@
 require 'chef/resource/lwrp_base'
 require 'chef/provider/lwrp_base'
 
-class Chef::Resource
+class ChefSystemdCookbook
   # resource for declarative allocation of system users and groups
   # http://www.freedesktop.org/software/systemd/man/sysusers.d.html
-  class SystemdSysuser < Chef::Resource::LWRPBase
+  class SysuserResource < Chef::Resource::LWRPBase
     resource_name :systemd_sysuser
 
     actions :create, :delete
@@ -48,10 +48,8 @@ class Chef::Resource
       "#{type} #{name} #{id} \"#{gecos}\" #{home}"
     end
   end
-end
 
-class Chef::Provider
-  class SystemdSysuser < Chef::Provider::LWRPBase
+  class SysuserProvider < Chef::Provider::LWRPBase
     DIR ||= '/etc/sysusers.d'.freeze
 
     use_inline_resources

--- a/libraries/tmpfile.rb
+++ b/libraries/tmpfile.rb
@@ -21,11 +21,11 @@
 require 'chef/resource/lwrp_base'
 require 'chef/provider/lwrp_base'
 
-class Chef::Resource
+class ChefSystemdCookbook
   # resource for configuration of files for creation,
   # deletion and cleaning of volatile and temporary files
   # http://www.freedesktop.org/software/systemd/man/tmpfiles.d.html
-  class SystemdTmpfile < Chef::Resource::LWRPBase
+  class TmpfileResource < Chef::Resource::LWRPBase
     resource_name :systemd_tmpfile
 
     actions :create, :delete
@@ -43,10 +43,8 @@ class Chef::Resource
                        C x X r R z Z t T h H a,a+ A,A+
                      )
   end
-end
 
-class Chef::Provider
-  class SystemdTmpfile < Chef::Provider::LWRPBase
+  class TmpfileProvider < Chef::Provider::LWRPBase
     DIR ||= '/etc/tmpfiles.d'.freeze
 
     use_inline_resources

--- a/libraries/udev_rules.rb
+++ b/libraries/udev_rules.rb
@@ -21,10 +21,10 @@
 require 'chef/resource/lwrp_base'
 require 'chef/resource/lwrp_base'
 
-class Chef::Resource
+class ChefSystemdCookbook
   # resource for managing udev rules
   # http://www.freedesktop.org/software/systemd/man/udev.html
-  class SystemdUdevRules < Chef::Resource::LWRPBase
+  class UdevRulesResource < Chef::Resource::LWRPBase
     VALID_UDEV_OPERATORS ||= %w( == != = += -= := ).freeze
     VALID_RULE_KEYS ||= %w( key operator value ).freeze
     VALID_UDEV_KEYS ||= %w(
@@ -43,9 +43,9 @@ class Chef::Resource
         specs.is_a?(Array) && specs.all? do |spec|
           spec.is_a?(Array) && spec.all? do |rule|
             rule.length == 3 &&
-            rule.keys.all? { |k| VALID_RULE_KEYS.include? k } &&
-            VALID_UDEV_KEYS.any? { |k| rule['key'].start_with? k } &&
-            VALID_UDEV_OPERATORS.include?(rule['operator'])
+              rule.keys.all? { |k| VALID_RULE_KEYS.include? k } &&
+              VALID_UDEV_KEYS.any? { |k| rule['key'].start_with? k } &&
+              VALID_UDEV_OPERATORS.include?(rule['operator'])
           end
         end
       end
@@ -59,10 +59,8 @@ class Chef::Resource
       end.join("\n")
     end
   end
-end
 
-class Chef::Provider
-  class SystemdUdevRules < Chef::Provider::LWRPBase
+  class UdevRulesProvider < Chef::Provider::LWRPBase
     DIR ||= '/etc/udev/rules.d'.freeze
 
     use_inline_resources

--- a/libraries/unit.rb
+++ b/libraries/unit.rb
@@ -24,10 +24,10 @@ require_relative 'systemd'
 require_relative 'helpers'
 require_relative 'conf'
 
-class Chef::Resource
+class ChefSystemdCookbook
   # base class for systemd unit resources
   # http://www.freedesktop.org/software/systemd/man/systemd.unit.html
-  class SystemdUnit < Chef::Resource::SystemdConf
+  class UnitResource < ChefSystemdCookbook::ConfResource
     include Chef::Mixin::ParamsValidate
 
     resource_name :systemd_unit
@@ -125,10 +125,8 @@ class Chef::Resource
       ["Alias=#{aliases.map { |a| "#{a}.#{conf_type}" }.join(' ')}"]
     end
   end
-end
 
-class Chef::Provider
-  class SystemdUnit < Chef::Provider::SystemdConf
+  class UnitProvider < ChefSystemdCookbook::ConfProvider
     provides :systemd_unit if defined?(provides)
     Systemd::Helpers::UNITS.reject { |u| u == :target }.each do |unit_type|
       provides "systemd_#{unit_type}".to_sym if defined?(provides)

--- a/libraries/units.rb
+++ b/libraries/units.rb
@@ -27,14 +27,16 @@
 
 # resources for management of systemd units
 
+require 'mixlib/shellout'
+
 require_relative 'systemd'
 require_relative 'unit'
 
 # TODO: deduplicate the boilerplate
-class Chef::Resource
+class ChefSystemdCookbook
   # resource for configuration of systemd automount units
   # http://www.freedesktop.org/software/systemd/man/systemd.automount.html
-  class SystemdAutomount < Chef::Resource::SystemdUnit
+  class AutomountResource < ChefSystemdCookbook::UnitResource
     resource_name :systemd_automount
 
     def conf_type(_ = nil)
@@ -50,7 +52,7 @@ class Chef::Resource
 
   # resource for configuration of systemd mount units
   # http://www.freedesktop.org/software/systemd/man/systemd.mount.html
-  class SystemdMount < Chef::Resource::SystemdUnit
+  class MountResource < ChefSystemdCookbook::UnitResource
     resource_name :systemd_mount
 
     def conf_type(_ = nil)
@@ -66,7 +68,7 @@ class Chef::Resource
 
   # resource for configuration of systemd path units
   # http://www.freedesktop.org/software/systemd/man/systemd.path.html
-  class SystemdPath < Chef::Resource::SystemdUnit
+  class PathResource < ChefSystemdCookbook::UnitResource
     resource_name :systemd_path
 
     def conf_type(_ = nil)
@@ -82,7 +84,7 @@ class Chef::Resource
 
   # resource for configuration of systemd service units
   # http://www.freedesktop.org/software/systemd/man/systemd.service.html
-  class SystemdService < Chef::Resource::SystemdUnit
+  class ServiceResource < ChefSystemdCookbook::UnitResource
     resource_name :systemd_service
 
     def conf_type(_ = nil)
@@ -98,7 +100,7 @@ class Chef::Resource
 
   # resource for configuration of systemd slice units
   # http://www.freedesktop.org/software/systemd/man/systemd.slice.html
-  class SystemdSlice < Chef::Resource::SystemdUnit
+  class SliceResource < ChefSystemdCookbook::UnitResource
     resource_name :systemd_slice
 
     def conf_type(_ = nil)
@@ -110,7 +112,7 @@ class Chef::Resource
 
   # resource for configuration of systemd socket units
   # http://www.freedesktop.org/software/systemd/man/systemd.socket.html
-  class SystemdSocket < Chef::Resource::SystemdUnit
+  class SocketResource < ChefSystemdCookbook::UnitResource
     resource_name :systemd_socket
 
     def conf_type(_ = nil)
@@ -126,7 +128,7 @@ class Chef::Resource
 
   # resource for configuration of systemd swap units
   # http://www.freedesktop.org/software/systemd/man/systemd.swap.html
-  class SystemdSwap < Chef::Resource::SystemdUnit
+  class SwapResource < ChefSystemdCookbook::UnitResource
     resource_name :systemd_swap
 
     def conf_type(_ = nil)
@@ -142,7 +144,7 @@ class Chef::Resource
 
   # resource for configuration of systemd target units
   # http://www.freedesktop.org/software/systemd/man/systemd.target.html
-  class SystemdTarget < Chef::Resource::SystemdUnit
+  class TargetResource < ChefSystemdCookbook::UnitResource
     resource_name :systemd_target
 
     def conf_type(_ = nil)
@@ -152,7 +154,7 @@ class Chef::Resource
 
   # resource for configuration of systemd timer units
   # http://www.freedesktop.org/software/systemd/man/systemd.timer.html
-  class SystemdTimer < Chef::Resource::SystemdUnit
+  class TimerResource < ChefSystemdCookbook::UnitResource
     resource_name :systemd_timer
 
     def conf_type(_ = nil)
@@ -165,12 +167,8 @@ class Chef::Resource
       yield
     end
   end
-end
 
-require 'mixlib/shellout'
-
-class Chef::Provider
-  class SystemdTarget < Chef::Provider::SystemdUnit
+  class TargetProvider < ChefSystemdCookbook::UnitProvider
     provides :systemd_target if defined?(provides)
 
     action :set_default do

--- a/libraries/util.rb
+++ b/libraries/util.rb
@@ -21,9 +21,9 @@
 require_relative 'helpers'
 require_relative 'conf'
 
-class Chef::Resource
+class ChefSystemdCookbook
   # base class for management of systemd utilities
-  class SystemdUtil < Chef::Resource::SystemdConf
+  class UtilResource < ChefSystemdCookbook::ConfResource
     resource_name :systemd_util
 
     attribute :drop_in, kind_of: [TrueClass, FalseClass], default: true
@@ -35,10 +35,8 @@ class Chef::Resource
       conf_type.capitalize
     end
   end
-end
 
-class Chef::Provider
-  class SystemdUtil < Chef::Provider::SystemdConf
+  class UtilProvider < ChefSystemdCookbook::ConfProvider
     provides :systemd_util if defined?(provides)
     Systemd::Helpers::UTILS.each do |util|
       provides "systemd_#{util}".to_sym if defined?(provides)

--- a/libraries/utils.rb
+++ b/libraries/utils.rb
@@ -24,10 +24,10 @@ require_relative 'systemd'
 require_relative 'util'
 
 # TODO: deduplicate the boilerplate
-class Chef::Resource
+class ChefSystemdCookbook
   # resource for managing systemd-bootchart
   # http://www.freedesktop.org/software/systemd/man/systemd-bootchart.html
-  class SystemdBootchart < Chef::Resource::SystemdUtil
+  class BootchartResource < ChefSystemdCookbook::UtilResource
     resource_name :systemd_bootchart
 
     def conf_type(_ = nil)
@@ -39,7 +39,7 @@ class Chef::Resource
 
   # resource for managing systemd-coredump
   # http://www.freedesktop.org/software/systemd/man/systemd-coredump.html
-  class SystemdCoredump < Chef::Resource::SystemdUtil
+  class CoredumpResource < ChefSystemdCookbook::UtilResource
     resource_name :systemd_coredump
 
     def conf_type(_ = nil)
@@ -51,7 +51,7 @@ class Chef::Resource
 
   # resource for managing systemd-sleep
   # http://www.freedesktop.org/software/systemd/man/systemd-sleep.html
-  class SystemdSleep < Chef::Resource::SystemdUtil
+  class SleepResource < ChefSystemdCookbook::UtilResource
     resource_name :systemd_sleep
 
     def conf_type(_ = nil)
@@ -63,7 +63,7 @@ class Chef::Resource
 
   # resource for managing systemd system mode defaults
   # http://www.freedesktop.org/software/systemd/man/systemd-system.conf.html
-  class SystemdSystem < Chef::Resource::SystemdUtil
+  class SystemResource < ChefSystemdCookbook::UtilResource
     resource_name :systemd_system
 
     def conf_type(_ = nil)
@@ -79,7 +79,7 @@ class Chef::Resource
 
   # resource for managing systemd user mode defaults
   # http://www.freedesktop.org/software/systemd/man/systemd-user.conf.html
-  class SystemdUser < Chef::Resource::SystemdUtil
+  class UserResource < ChefSystemdCookbook::UtilResource
     resource_name :systemd_user
 
     def conf_type(_ = nil)

--- a/spec/unit/helpers_spec.rb
+++ b/spec/unit/helpers_spec.rb
@@ -2,28 +2,28 @@ require 'spec_helper'
 
 describe Systemd::Helpers do
   let(:unit) do
-    Chef::Resource::SystemdService.new('unit')
+    ChefSystemdCookbook::ServiceResource.new('unit')
   end
 
   let(:drop_in_unit) do
-    d = Chef::Resource::SystemdService.new('drop_in')
+    d = ChefSystemdCookbook::ServiceResource.new('drop_in')
     d.drop_in(true)
     d.override 'httpd'
     d
   end
 
   let(:user_unit) do
-    d = Chef::Resource::SystemdService.new('user')
+    d = ChefSystemdCookbook::ServiceResource.new('user')
     d.mode :user
     d
   end
 
   let(:daemon) do
-    Chef::Resource::SystemdTimesyncd.new('daemon')
+    ChefSystemdCookbook::TimesyncdResource.new('daemon')
   end
 
   let(:drop_in_daemon) do
-    d = Chef::Resource::SystemdTimesyncd.new('drop_in')
+    d = ChefSystemdCookbook::TimesyncdResource.new('drop_in')
     d.drop_in(true)
     d
   end

--- a/spec/unit/resource_systemd_automount_spec.rb
+++ b/spec/unit/resource_systemd_automount_spec.rb
@@ -1,8 +1,8 @@
 require 'spec_helper'
 
-describe Chef::Resource::SystemdAutomount do
+describe ChefSystemdCookbook::AutomountResource do
   let(:automount) do
-    a = Chef::Resource::SystemdAutomount.new('automount')
+    a = ChefSystemdCookbook::AutomountResource.new('automount')
     a.wanted_by 'multi-user.target'
     a.after 'network.target'
     a.where '/srv/automount'

--- a/spec/unit/resource_systemd_binfmt_spec.rb
+++ b/spec/unit/resource_systemd_binfmt_spec.rb
@@ -1,8 +1,8 @@
 require 'spec_helper'
 
-describe Chef::Resource::SystemdBinfmt do
+describe ChefSystemdCookbook::BinfmtResource do
   let(:binfmt) do
-    b = Chef::Resource::SystemdBinfmt.new('DOSWin')
+    b = ChefSystemdCookbook::BinfmtResource.new('DOSWin')
     b.magic 'MZ'
     b.interpreter '/usr/bin/wine'
     b

--- a/spec/unit/resource_systemd_bootchart_spec.rb
+++ b/spec/unit/resource_systemd_bootchart_spec.rb
@@ -1,8 +1,8 @@
 require 'spec_helper'
 
-describe Chef::Resource::SystemdBootchart do
+describe ChefSystemdCookbook::BootchartResource do
   let(:bootchart) do
-    b = Chef::Resource::SystemdBootchart.new('bootchart')
+    b = ChefSystemdCookbook::BootchartResource.new('bootchart')
     b.output '/var/tmp'
     b
   end

--- a/spec/unit/resource_systemd_conf_spec.rb
+++ b/spec/unit/resource_systemd_conf_spec.rb
@@ -1,8 +1,8 @@
 require 'spec_helper'
 
-describe Chef::Resource::SystemdConf do
+describe ChefSystemdCookbook::ConfResource do
   let(:daemon) do
-    d = Chef::Resource::SystemdJournald.new('journal')
+    d = ChefSystemdCookbook::JournaldResource.new('journal')
     d.storage 'auto'
     d.forward_to_syslog true
     d.compress true

--- a/spec/unit/resource_systemd_coredump_spec.rb
+++ b/spec/unit/resource_systemd_coredump_spec.rb
@@ -1,8 +1,8 @@
 require 'spec_helper'
 
-describe Chef::Resource::SystemdCoredump do
+describe ChefSystemdCookbook::CoredumpResource do
   let(:coredump) do
-    c = Chef::Resource::SystemdCoredump.new('coredump')
+    c = ChefSystemdCookbook::CoredumpResource.new('coredump')
     c.compress true
     c.storage 'external'
     c

--- a/spec/unit/resource_systemd_daemon_spec.rb
+++ b/spec/unit/resource_systemd_daemon_spec.rb
@@ -1,8 +1,8 @@
 require 'spec_helper'
 
-describe Chef::Resource::SystemdDaemon do
+describe ChefSystemdCookbook::DaemonResource do
   let(:daemon) do
-    d = Chef::Resource::SystemdJournald.new('journal')
+    d = ChefSystemdCookbook::JournaldResource.new('journal')
     d.storage 'auto'
     d.forward_to_syslog true
     d.compress true

--- a/spec/unit/resource_systemd_journald_spec.rb
+++ b/spec/unit/resource_systemd_journald_spec.rb
@@ -1,8 +1,8 @@
 require 'spec_helper'
 
-describe Chef::Resource::SystemdJournald do
+describe ChefSystemdCookbook::JournaldResource do
   let(:journald) do
-    d = Chef::Resource::SystemdJournald.new('journal')
+    d = ChefSystemdCookbook::JournaldResource.new('journal')
     d.storage 'auto'
     d.forward_to_syslog true
     d.compress true

--- a/spec/unit/resource_systemd_logind_spec.rb
+++ b/spec/unit/resource_systemd_logind_spec.rb
@@ -1,8 +1,8 @@
 require 'spec_helper'
 
-describe Chef::Resource::SystemdLogind do
+describe ChefSystemdCookbook::LogindResource do
   let(:logind) do
-    l = Chef::Resource::SystemdLogind.new('logind')
+    l = ChefSystemdCookbook::LogindResource.new('logind')
     l.remove_ipc true
     l
   end

--- a/spec/unit/resource_systemd_mount_spec.rb
+++ b/spec/unit/resource_systemd_mount_spec.rb
@@ -1,8 +1,8 @@
 require 'spec_helper'
 
-describe Chef::Resource::SystemdMount do
+describe ChefSystemdCookbook::MountResource do
   let(:mount) do
-    m = Chef::Resource::SystemdMount.new('mount')
+    m = ChefSystemdCookbook::MountResource.new('mount')
     m.wanted_by 'multi-user.target'
     m.after 'network.target'
     m.what '/dev/vda'

--- a/spec/unit/resource_systemd_networkd_link_spec.rb
+++ b/spec/unit/resource_systemd_networkd_link_spec.rb
@@ -1,8 +1,8 @@
 require 'spec_helper'
 
-describe Chef::Resource::SystemdNetworkdLink do
+describe ChefSystemdCookbook::NetworkdLinkResource do
   let(:link) do
-    l = Chef::Resource::SystemdNetworkdLink.new('link')
+    l = ChefSystemdCookbook::NetworkdLinkResource.new('link')
     l.match_mac_addr '12:34:56:78:9a:bc'
     l.driver 'brcmsmac'
     l.path 'pci-0000:02:00.0-*'

--- a/spec/unit/resource_systemd_path_spec.rb
+++ b/spec/unit/resource_systemd_path_spec.rb
@@ -1,8 +1,8 @@
 require 'spec_helper'
 
-describe Chef::Resource::SystemdPath do
+describe ChefSystemdCookbook::PathResource do
   let(:path) do
-    p = Chef::Resource::SystemdPath.new('path')
+    p = ChefSystemdCookbook::PathResource.new('path')
     p.wanted_by 'multi-user.target'
     p.after 'network.target'
     p.unit 'worker.service'

--- a/spec/unit/resource_systemd_resolved_spec.rb
+++ b/spec/unit/resource_systemd_resolved_spec.rb
@@ -1,8 +1,8 @@
 require 'spec_helper'
 
-describe Chef::Resource::SystemdResolved do
+describe ChefSystemdCookbook::ResolvedResource do
   let(:resolved) do
-    r = Chef::Resource::SystemdResolved.new('resolved')
+    r = ChefSystemdCookbook::ResolvedResource.new('resolved')
     r.dns '8.8.8.8 8.8.4.4'
     r.fallback_dns '208.67.222.222 208.67.220.220'
     r

--- a/spec/unit/resource_systemd_run_spec.rb
+++ b/spec/unit/resource_systemd_run_spec.rb
@@ -1,8 +1,8 @@
 require 'spec_helper'
 
-describe Chef::Resource::SystemdRun do
+describe ChefSystemdCookbook::SystemdRunResource do
   let(:svc_run) do
-    Chef::Resource::SystemdRun.new("transient-env.service").tap do |r|
+    ChefSystemdCookbook::SystemdRunResource.new("transient-env.service").tap do |r|
       r.command 'env'
       r.service_type 'simple'
       r.setenv({ 'FOO' => 0, 'BAR' => 1 })

--- a/spec/unit/resource_systemd_service_spec.rb
+++ b/spec/unit/resource_systemd_service_spec.rb
@@ -1,8 +1,8 @@
 require 'spec_helper'
 
-describe Chef::Resource::SystemdService do
+describe ChefSystemdCookbook::ServiceResource do
   let(:service) do
-    s = Chef::Resource::SystemdService.new('service')
+    s = ChefSystemdCookbook::ServiceResource.new('service')
     s.description 'test unit'
     s.documentation 'http://example.com'
     s.wanted_by 'multi-user.target'

--- a/spec/unit/resource_systemd_sleep_spec.rb
+++ b/spec/unit/resource_systemd_sleep_spec.rb
@@ -1,8 +1,8 @@
 require 'spec_helper'
 
-describe Chef::Resource::SystemdSleep do
+describe ChefSystemdCookbook::SleepResource do
   let(:sleep) do
-    s = Chef::Resource::SystemdSleep.new('sleep')
+    s = ChefSystemdCookbook::SleepResource.new('sleep')
     s.suspend_state 'freeze'
     s
   end

--- a/spec/unit/resource_systemd_slice_spec.rb
+++ b/spec/unit/resource_systemd_slice_spec.rb
@@ -1,8 +1,8 @@
 require 'spec_helper'
 
-describe Chef::Resource::SystemdSlice do
+describe ChefSystemdCookbook::SliceResource do
   let(:slice) do
-    s = Chef::Resource::SystemdSlice.new('slice')
+    s = ChefSystemdCookbook::SliceResource.new('slice')
     s.wanted_by 'multi-user.target'
     s.after 'network.target'
     s.memory_limit '1G'

--- a/spec/unit/resource_systemd_socket_spec.rb
+++ b/spec/unit/resource_systemd_socket_spec.rb
@@ -1,8 +1,8 @@
 require 'spec_helper'
 
-describe Chef::Resource::SystemdSocket do
+describe ChefSystemdCookbook::SocketResource do
   let(:socket) do
-    s = Chef::Resource::SystemdSocket.new('socket')
+    s = ChefSystemdCookbook::SocketResource.new('socket')
     s.wanted_by 'multi-user.target'
     s.after 'network.target'
     s.listen_stream '8080'

--- a/spec/unit/resource_systemd_swap_spec.rb
+++ b/spec/unit/resource_systemd_swap_spec.rb
@@ -1,8 +1,8 @@
 require 'spec_helper'
 
-describe Chef::Resource::SystemdSwap do
+describe ChefSystemdCookbook::SwapResource do
   let(:swap) do
-    s = Chef::Resource::SystemdSwap.new('swap')
+    s = ChefSystemdCookbook::SwapResource.new('swap')
     s.wanted_by 'multi-user.target'
     s.after 'network.target'
     s.what '/dev/swap'

--- a/spec/unit/resource_systemd_system_spec.rb
+++ b/spec/unit/resource_systemd_system_spec.rb
@@ -1,8 +1,8 @@
 require 'spec_helper'
 
-describe Chef::Resource::SystemdSystem do
+describe ChefSystemdCookbook::SystemResource do
   let(:system) do
-    s = Chef::Resource::SystemdSystem.new('system')
+    s = ChefSystemdCookbook::SystemResource.new('system')
     s.dump_core true
     s.crash_shell false # crash override
     s

--- a/spec/unit/resource_systemd_sysuser_spec.rb
+++ b/spec/unit/resource_systemd_sysuser_spec.rb
@@ -1,8 +1,8 @@
 require 'spec_helper'
 
-describe Chef::Resource::SystemdSysuser do
+describe ChefSystemdCookbook::SysuserResource do
   let(:sysuser) do
-    u = Chef::Resource::SystemdSysuser.new('_testuser')
+    u = ChefSystemdCookbook::SysuserResource.new('_testuser')
     u.id 65_530
     u.gecos 'my test user'
     u.home '/var/lib/testuser'

--- a/spec/unit/resource_systemd_target_spec.rb
+++ b/spec/unit/resource_systemd_target_spec.rb
@@ -1,8 +1,8 @@
 require 'spec_helper'
 
-describe Chef::Resource::SystemdTarget do
+describe ChefSystemdCookbook::TargetResource do
   let(:target) do
-    t = Chef::Resource::SystemdTarget.new('target')
+    t = ChefSystemdCookbook::TargetResource.new('target')
     t.wanted_by 'multi-user.target'
     t.after 'network.target'
     t

--- a/spec/unit/resource_systemd_timer_spec.rb
+++ b/spec/unit/resource_systemd_timer_spec.rb
@@ -1,8 +1,8 @@
 require 'spec_helper'
 
-describe Chef::Resource::SystemdTimer do
+describe ChefSystemdCookbook::TimerResource do
   let(:timer) do
-    t = Chef::Resource::SystemdTimer.new('target')
+    t = ChefSystemdCookbook::TimerResource.new('target')
     t.wanted_by 'multi-user.target'
     t.after 'network.target'
     t.on_calendar 'hourly'

--- a/spec/unit/resource_systemd_timesyncd_spec.rb
+++ b/spec/unit/resource_systemd_timesyncd_spec.rb
@@ -1,8 +1,8 @@
 require 'spec_helper'
 
-describe Chef::Resource::SystemdTimesyncd do
+describe ChefSystemdCookbook::TimesyncdResource do
   let(:timesyncd) do
-    t = Chef::Resource::SystemdTimesyncd.new('timesyncd')
+    t = ChefSystemdCookbook::TimesyncdResource.new('timesyncd')
     t.ntp '0.pool.ntp.org'
     t.fallback_ntp '0.centos.pool.ntp.org'
     t

--- a/spec/unit/resource_systemd_udev_rules.rb
+++ b/spec/unit/resource_systemd_udev_rules.rb
@@ -1,8 +1,8 @@
 require 'spec_helper'
 
-describe Chef::Resource::SystemdUdevRules do
+describe ChefSystemdResource::UdevRulesResource do
   let(:udev_rules) do
-    u = Chef::Resource::SystemdUdevRules.new('udev_rules')
+    u = ChefSystemdResource::UdevRulesResource.new('udev_rules')
     u.rules [
       [
         {'key' => 'SUBSYSTEM', 'operator' => '==', 'value' => 'block'},

--- a/spec/unit/resource_systemd_unit_spec.rb
+++ b/spec/unit/resource_systemd_unit_spec.rb
@@ -1,8 +1,8 @@
 require 'spec_helper'
 
-describe Chef::Resource::SystemdUnit do
+describe ChefSystemdCookbook::UnitResource do
   let(:unit) do
-    u = Chef::Resource::SystemdService.new('service')
+    u = ChefSystemdCookbook::ServiceResource.new('service')
     u.description 'test unit'
     u.documentation 'http://example.com'
     u.wanted_by 'multi-user.target'

--- a/spec/unit/resource_systemd_user_spec.rb
+++ b/spec/unit/resource_systemd_user_spec.rb
@@ -1,8 +1,8 @@
 require 'spec_helper'
 
-describe Chef::Resource::SystemdUser do
+describe ChefSystemdCookbook::UserResource do
   let(:user) do
-    u = Chef::Resource::SystemdUser.new('user')
+    u = ChefSystemdCookbook::UserResource.new('user')
     u.dump_core true
     u.crash_shell false # crash override
     u

--- a/spec/unit/resource_systemd_util_spec.rb
+++ b/spec/unit/resource_systemd_util_spec.rb
@@ -1,8 +1,8 @@
 require 'spec_helper'
 
-describe Chef::Resource::SystemdUtil do
+describe ChefSystemdCookbook::UtilResource do
   let(:util) do
-    u = Chef::Resource::SystemdUtil.new('util')
+    u = ChefSystemdCookbook::UtilResource.new('util')
     u.conf_type :bootchart
     u
   end


### PR DESCRIPTION
i think we're about ready to start pushing some of this upstream, in which case we're going to want to not be sitting on the `Chef::Resource::*` names for these resources. This moves us to our own goofy namespace instead.

/cc @ranjib @stevendanna 
