### PR TITLE
Add RandomizedDelaySec support to systemd_timer

### DIFF
--- a/README.md
+++ b/README.md
@@ -658,6 +658,7 @@ end
 |on_unit_active_sec|see docs|nil|
 |on_unit_inactive_sec|see docs|nil|
 |persistent|see docs|nil|
+|randomized_delay_sec|see docs|nil|
 |unit|see docs|nil|
 |wake_system|see docs|nil|
 

--- a/libraries/systemd.rb
+++ b/libraries/systemd.rb
@@ -740,6 +740,7 @@ module Systemd
       'OnUnitInactiveSec' => { kind_of: [String, Integer] },
       'OnCalendar' => {},
       'AccuracySec' => { kind_of: [String, Integer] },
+      'RandomizedDelaySec' => { kind_of: [String, Integer] },
       'WakeSystem' => { kind_of: [TrueClass, FalseClass] },
       'RemainAfterElapse' => { kind_of: [TrueClass, FalseClass] },
       'RandomSec' => { kind_of: [String, Integer] }


### PR DESCRIPTION
As per official [doc](https://www.freedesktop.org/software/systemd/man/systemd.timer.html#RandomizedDelaySec=).

I'm leaving version bump up to maintainer decision.