### PR TITLE
pass the method name to superclass #method_missing

### DIFF
--- a/libraries/mixin.rb
+++ b/libraries/mixin.rb
@@ -33,7 +33,7 @@ module SystemdCookbook
             if @context && respond_to?("#{@context}_#{name}".to_sym)
               send("#{@context}_#{name}".to_sym, *args, &blk)
             else
-              super(*args, &blk)
+              super(name, *args, &blk)
             end
           end
 


### PR DESCRIPTION
woops, left off the crucial first arg