### PR TITLE
add precursor drop-in property

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -15,7 +15,7 @@ verifier:
 
 platforms:
   - name: centos-7.3
-  - name: fedora-25
+  - name: fedora-26
     run_list:
       - recipe[yum::dnf_yum_compat]
   - name: debian-9.0

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ the systemd project covers a lot of territory, below are some resources that can
  - [systemd docs][docs]
  - [Lennart's blog series][blog]
 
-We also provide reference [documentation](resources.md) for this cookbook's resources.
+We also recommend taking a look at the test cookbook, which doubles as usage examples.
 
 ## Overview
 

--- a/README.md
+++ b/README.md
@@ -150,6 +150,8 @@ Prefixing section headings onto property names is necessary to avoid conflicts b
 |target|systemd_target|systemd_target_drop_in|
 |timer|systemd_timer|systemd_timer_drop_in|
 
+For resetting properties in drop-ins, use the `resets` property ([example](https://github.com/nathwill/chef-systemd/blob/master/test/fixtures/cookbooks/test/recipes/drop_ins.rb)).
+
 ##### systemd_automount
 
 resource for managing [automount][automount] units.
@@ -257,6 +259,7 @@ See systemd_automount docs for additional properties.
 |override|name of unit resource is drop-in for|nil|String|
 |user|see systemd_unit docs|nil|String|
 |drop_in_name|combo of override and resource names, used internally by provider|`lazy { "#{override}-#{name}" }`|String|
+|resets|hash of sections/properties to reset|{}|Hash|
 
 ##### systemd_mount
 
@@ -471,6 +474,7 @@ see systemd_mount resource for additional properties.
 |override|name of unit resource is drop-in for|nil|String|
 |user|see systemd_unit docs|nil|String|
 |drop_in_name|combo of override and resource names, used internally by provider|`lazy { "#{override}-#{name}" }`|String|
+|resets|hash of sections/properties to reset|{}|Hash|
 
 ##### systemd_path
 
@@ -584,6 +588,7 @@ see systemd_path resource for additional properties.
 |override|name of unit resource is drop-in for|nil|String|
 |user|see systemd_unit docs|nil|String|
 |drop_in_name|combo of override and resource names, used internally by provider|`lazy { "#{override}-#{name}" }`|String|
+|resets|hash of sections/properties to reset|{}|Hash|
 
 ##### systemd_service
 
@@ -821,6 +826,7 @@ see systemd_service resource for additional properties.
 |override|name of unit resource is drop-in for|nil|String|
 |user|see systemd_unit docs|nil|String|
 |drop_in_name|combo of override and resource names, used internally by provider|`lazy { "#{override}-#{name}" }`|String|
+|resets|hash of sections/properties to reset|{}|Hash|
 
 ##### systemd_slice
 
@@ -952,6 +958,7 @@ see systemd_slice resource for additional properties.
 |override|name of unit resource is drop-in for|nil|String|
 |user|see systemd_unit docs|nil|String|
 |drop_in_name|combo of override and resource names, used internally by provider|`lazy { "#{override}-#{name}" }`|String|
+|resets|hash of sections/properties to reset|{}|Hash|
 
 ##### systemd_socket
 
@@ -1215,6 +1222,7 @@ see systemd_socket resource for additional properties.
 |override|name of unit resource is drop-in for|nil|String|
 |user|see systemd_unit docs|nil|String|
 |drop_in_name|combo of override and resource names, used internally by provider|`lazy { "#{override}-#{name}" }`|String|
+|resets|hash of sections/properties to reset|{}|Hash|
 
 ##### systemd_swap
 
@@ -1426,6 +1434,7 @@ see systemd_swap resource for additional options.
 |override|name of unit resource is drop-in for|nil|String|
 |user|see systemd_unit docs|nil|String|
 |drop_in_name|combo of override and resource names, used internally by provider|`lazy { "#{override}-#{name}" }`|String|
+|resets|hash of sections/properties to reset|{}|Hash|
 
 ##### systemd_target
 
@@ -1531,6 +1540,7 @@ see systemd_target resource for additional properties.
 |override|name of unit resource is drop-in for|nil|String|
 |user|see systemd_unit docs|nil|String|
 |drop_in_name|combo of override and resource names, used internally by provider|`lazy { "#{override}-#{name}" }`|String|
+|resets|hash of sections/properties to reset|{}|Hash|
 
 ##### systemd_timer
 
@@ -1648,6 +1658,7 @@ see systemd_timer resource for additional properties
 |override|name of unit resource is drop-in for|nil|String|
 |user|see systemd_unit docs|nil|String|
 |drop_in_name|combo of override and resource names, used internally by provider|`lazy { "#{override}-#{name}" }`|String|
+|resets|hash of sections/properties to reset|{}|Hash|
 
 #### System Services
 

--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ Prefixing section headings onto property names is necessary to avoid conflicts b
 |target|systemd_target|systemd_target_drop_in|
 |timer|systemd_timer|systemd_timer_drop_in|
 
-For resetting properties in drop-ins, use the `resets` property ([example](https://github.com/nathwill/chef-systemd/blob/master/test/fixtures/cookbooks/test/recipes/drop_ins.rb)).
+For resetting properties in drop-ins (e.g. `ExecStart`), use the `precursor` property ([example](https://github.com/nathwill/chef-systemd/blob/master/test/fixtures/cookbooks/test/recipes/drop_ins.rb)).
 
 ##### systemd_automount
 
@@ -259,7 +259,7 @@ See systemd_automount docs for additional properties.
 |override|name of unit resource is drop-in for|nil|String|
 |user|see systemd_unit docs|nil|String|
 |drop_in_name|combo of override and resource names, used internally by provider|`lazy { "#{override}-#{name}" }`|String|
-|resets|hash of sections/properties to reset|{}|Hash|
+|precursor|hash of sections/properties to front-load into configuration|{}|Hash|
 
 ##### systemd_mount
 
@@ -474,7 +474,7 @@ see systemd_mount resource for additional properties.
 |override|name of unit resource is drop-in for|nil|String|
 |user|see systemd_unit docs|nil|String|
 |drop_in_name|combo of override and resource names, used internally by provider|`lazy { "#{override}-#{name}" }`|String|
-|resets|hash of sections/properties to reset|{}|Hash|
+|precursor|hash of sections/properties to front-load into configuration|{}|Hash|
 
 ##### systemd_path
 
@@ -588,7 +588,7 @@ see systemd_path resource for additional properties.
 |override|name of unit resource is drop-in for|nil|String|
 |user|see systemd_unit docs|nil|String|
 |drop_in_name|combo of override and resource names, used internally by provider|`lazy { "#{override}-#{name}" }`|String|
-|resets|hash of sections/properties to reset|{}|Hash|
+|precursor|hash of sections/properties to front-load into configuration|{}|Hash|
 
 ##### systemd_service
 
@@ -826,7 +826,7 @@ see systemd_service resource for additional properties.
 |override|name of unit resource is drop-in for|nil|String|
 |user|see systemd_unit docs|nil|String|
 |drop_in_name|combo of override and resource names, used internally by provider|`lazy { "#{override}-#{name}" }`|String|
-|resets|hash of sections/properties to reset|{}|Hash|
+|precursor|hash of sections/properties to front-load into configuration|{}|Hash|
 
 ##### systemd_slice
 
@@ -958,7 +958,7 @@ see systemd_slice resource for additional properties.
 |override|name of unit resource is drop-in for|nil|String|
 |user|see systemd_unit docs|nil|String|
 |drop_in_name|combo of override and resource names, used internally by provider|`lazy { "#{override}-#{name}" }`|String|
-|resets|hash of sections/properties to reset|{}|Hash|
+|precursor|hash of sections/properties to front-load into configuration|{}|Hash|
 
 ##### systemd_socket
 
@@ -1222,7 +1222,7 @@ see systemd_socket resource for additional properties.
 |override|name of unit resource is drop-in for|nil|String|
 |user|see systemd_unit docs|nil|String|
 |drop_in_name|combo of override and resource names, used internally by provider|`lazy { "#{override}-#{name}" }`|String|
-|resets|hash of sections/properties to reset|{}|Hash|
+|precursor|hash of sections/properties to front-load into configuration|{}|Hash|
 
 ##### systemd_swap
 
@@ -1434,7 +1434,7 @@ see systemd_swap resource for additional options.
 |override|name of unit resource is drop-in for|nil|String|
 |user|see systemd_unit docs|nil|String|
 |drop_in_name|combo of override and resource names, used internally by provider|`lazy { "#{override}-#{name}" }`|String|
-|resets|hash of sections/properties to reset|{}|Hash|
+|precursor|hash of sections/properties to front-load into configuration|{}|Hash|
 
 ##### systemd_target
 
@@ -1540,7 +1540,7 @@ see systemd_target resource for additional properties.
 |override|name of unit resource is drop-in for|nil|String|
 |user|see systemd_unit docs|nil|String|
 |drop_in_name|combo of override and resource names, used internally by provider|`lazy { "#{override}-#{name}" }`|String|
-|resets|hash of sections/properties to reset|{}|Hash|
+|precursor|hash of sections/properties to front-load into configuration|{}|Hash|
 
 ##### systemd_timer
 
@@ -1658,7 +1658,7 @@ see systemd_timer resource for additional properties
 |override|name of unit resource is drop-in for|nil|String|
 |user|see systemd_unit docs|nil|String|
 |drop_in_name|combo of override and resource names, used internally by provider|`lazy { "#{override}-#{name}" }`|String|
-|resets|hash of sections/properties to reset|{}|Hash|
+|precursor|hash of sections/properties to front-load into configuration|{}|Hash|
 
 #### System Services
 

--- a/test/fixtures/cookbooks/test/recipes/drop_ins.rb
+++ b/test/fixtures/cookbooks/test/recipes/drop_ins.rb
@@ -22,7 +22,7 @@ end
 
 systemd_service_drop_in 'systemd-ask-password-console' do
   override 'systemd-ask-password-console.service'
-  resets 'Service' => ['ExecStart']
+  precursor 'Service' => {'ExecStart' => nil}
   service do
     exec_start '/usr/bin/systemd-tty-ask-password-agent --watch --console'
   end

--- a/test/fixtures/cookbooks/test/recipes/drop_ins.rb
+++ b/test/fixtures/cookbooks/test/recipes/drop_ins.rb
@@ -22,8 +22,9 @@ end
 
 systemd_service_drop_in 'systemd-ask-password-console' do
   override 'systemd-ask-password-console.service'
-  unit do
-    description 'blah blah blah'
+  resets 'Service' => ['ExecStart']
+  service do
+    exec_start '/usr/bin/systemd-tty-ask-password-agent --watch --console'
   end
 end
 

--- a/test/integration/default/drop_ins_spec.rb
+++ b/test/integration/default/drop_ins_spec.rb
@@ -36,8 +36,7 @@ control 'creates service drop-ins' do
     its(:content) do
       should eq <<EOT
 [Service]
-ExecStart =
-[Service]
+ExecStart = 
 ExecStart = /usr/bin/systemd-tty-ask-password-agent --watch --console
 EOT
     end

--- a/test/integration/default/drop_ins_spec.rb
+++ b/test/integration/default/drop_ins_spec.rb
@@ -35,8 +35,10 @@ control 'creates service drop-ins' do
   describe file('/etc/systemd/system/systemd-ask-password-console.service.d/systemd-ask-password-console.conf') do
     its(:content) do
       should eq <<EOT
-[Unit]
-Description = blah blah blah
+[Service]
+ExecStart =
+[Service]
+ExecStart = /usr/bin/systemd-tty-ask-password-agent --watch --console
 EOT
     end
   end


### PR DESCRIPTION
as discussed in #110, the `overrides` functionality from v2 got missed in the rewrite for v3. while it's possible to address by using multiple drop-in resources along with careful naming, it's a lot easier for users to perform the resets in the same resource.

there's also a use case for certain unit properties (e.g. ExecStartPre, or ExecStop) which have additive rather than substitutive effects when repeated in a unit file, can not be properly reflected in the resource property -> hash conversion.

this addresses both concerns by implementing a free-form precursor property which accepts a hash with the unit headings as the keys, and property:value pairs as the values (i.e. same format as upstream systemd_unit `content` property). By using Hash#compare_by_identity, we're able to merge duplicated properties into the property-derived hash before converting to the final ini, avoiding the need to duplicate section headings or do fragile string editing

to elaborate... a resource like:

```ruby
systemd_service_drop_in 'fix-start' do
  override 'nginx.service'
  precursor 'Service' => { 'ExecStart' => nil }
  service do
    exec_start '/usr/bin/nginx -d'
  end
end
```

would yield the following drop-in:

```ini
[Service]
ExecStart =
ExecStart = /usr/bin/nginx -d
```

thus effectively resetting the start-command to `/usr/bin/nginx -d`.

and a resource like:

```ruby
systemd_service_drop_in 'pre-start-tasks' do
  override 'my-app.service'
  precursor 'Service' => { 'ExecStartPre' => '/usr/bin/download my-app' }
  service do
    exec_start_pre '/usr/bin/register my-app'
  end
end
```

would yield

```ini
[Service]
ExecStartPre = /usr/bin/download my-app
ExecStartPre = /usr/bin/register my-app
```

with both commands being run by systemd before the ExecStart command.