### PR TITLE
Requires dbus gem only when needed

### DIFF
--- a/recipes/reload.rb
+++ b/recipes/reload.rb
@@ -17,10 +17,9 @@
 # limitations under the License.
 #
 
-require 'dbus/systemd/manager'
-
 Chef.event_handler do
   on :run_completed do
+    require 'dbus/systemd/manager'
     mgr = DBus::Systemd::Manager.new
     mgr.Reload
   end

--- a/recipes/rtc.rb
+++ b/recipes/rtc.rb
@@ -19,10 +19,9 @@
 # https://www.freedesktop.org/software/systemd/man/timedatectl.html
 #
 
-require 'dbus/systemd/timedated'
-
 ruby_block 'set-rtc' do
   block do
+    require 'dbus/systemd/timedated'
     DBus::Systemd::Timedated.new.SetLocalRTC(
       node['systemd']['rtc_mode'] == 'local',
       node['systemd']['fix_rtc'], false
@@ -30,6 +29,7 @@ ruby_block 'set-rtc' do
   end
 
   not_if do
+    require 'dbus/systemd/timedated'
     local = node['systemd']['rtc_mode'] == 'local'
     DBus::Systemd::Timedated.new.properties['LocalRTC'] == local
   end

--- a/resources/machine.rb
+++ b/resources/machine.rb
@@ -1,5 +1,3 @@
-require 'dbus/systemd/machined'
-
 resource_name :systemd_machine
 provides :systemd_machine
 
@@ -13,6 +11,7 @@ default_action :start
 
 action_class do
   def machine_running?(name)
+    require 'dbus/systemd/machined'
     machine = DBus::Systemd::Machined::Machine.new(name)
     machine.properties['State'] == 'running'
   rescue DBus::Error => e

--- a/resources/machine_image.rb
+++ b/resources/machine_image.rb
@@ -1,6 +1,3 @@
-require 'dbus/systemd/machined'
-require 'dbus/systemd/importd'
-
 resource_name :systemd_machine_image
 provides :systemd_machine_image
 
@@ -38,6 +35,7 @@ action :pull do
 end
 
 action :set_properties do
+  require 'dbus/systemd/machined'
   execute "set-machine-read-only-#{new_resource.name}" do
     command "machinectl read-only #{new_resource.name} #{new_resource.read_only}"
     not_if { new_resource.read_only.nil? }
@@ -54,6 +52,7 @@ action :set_properties do
 end
 
 action :clone do
+  require 'dbus/systemd/machined'
   ruby_block "clone-machine-image-#{new_resource.name}" do
     block do
       mgr = DBus::Systemd::Machined::Manager.new


### PR DESCRIPTION
Delay the require to the last moment when the code is actually
required.
This kind of lazy loading have multiple advantages, the main one
is that the gem is not required for ChefSpec tests in contingent
cookbooks.

This should fix #105 

*Cc.* @aboten