### PR TITLE
remove requirement for VLAN Id to be set (fixes #126)

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -15,10 +15,10 @@ verifier:
 
 platforms:
   - name: centos-7.4
-  - name: fedora-26
+  - name: fedora-27
     run_list:
       - recipe[yum::dnf_yum_compat]
-  - name: debian-9.2
+  - name: debian-9.3
     run_list:
       - recipe[debian::backports]
       - recipe[apt]

--- a/libraries/data.rb
+++ b/libraries/data.rb
@@ -1144,7 +1144,6 @@ module SystemdCookbook
       'VLAN' => {
         'Id' => {
           kind_of: Integer,
-          required: true,
           equal_to: 0.upto(4094).to_a,
         },
       },

--- a/libraries/data.rb
+++ b/libraries/data.rb
@@ -666,7 +666,6 @@ module SystemdCookbook
       'Automount' => {
         'Where' => {
           kind_of: String,
-          required: true,
           callbacks: {
             'is an absolute path' => ->(spec) { Pathname.new(spec).absolute? },
           },
@@ -698,11 +697,9 @@ module SystemdCookbook
       'Mount' => {
         'What' => {
           kind_of: String,
-          required: true,
         },
         'Where' => {
           kind_of: String,
-          required: true,
           callbacks: {
             'absolute path' => ->(s) { Pathname.new(s).absolute? },
           },
@@ -895,7 +892,6 @@ module SystemdCookbook
       'Swap' => {
         'What' => {
           kind_of: String,
-          required: true,
           callbacks: {
             'is an absolute path' => ->(s) { Pathname.new(s).absolute? },
           },
@@ -1101,11 +1097,9 @@ module SystemdCookbook
         'Description' => Common::STRING,
         'Name' => {
           kind_of: String,
-          required: true,
         },
         'Kind' => {
           kind_of: String,
-          required: true,
           equal_to: %w(
             bond
             bridge

--- a/resources/binfmt.rb
+++ b/resources/binfmt.rb
@@ -1,7 +1,7 @@
 resource_name :systemd_binfmt
 provides :systemd_binfmt
 
-property :name, String, required: true, name_attribute: true, callbacks: {
+property :binfmt_name, String, name_property: true, identity: true, callbacks: {
   'does not contain /' => ->(s) { !s.match(Regexp.new('/')) },
 }
 property :type, String, equal_to: %w(M E), default: 'M'

--- a/resources/sysuser.rb
+++ b/resources/sysuser.rb
@@ -2,7 +2,7 @@ resource_name :systemd_sysuser
 provides :systemd_sysuser
 
 property :type, String, equal_to: %w(u g m r), default: 'u'
-property :name, String, name_attribute: true, required: true, callbacks: {
+property :sysuser_name, String, name_property: true, identity: true, callbacks: {
   'is less than 31 chars' => ->(s) { s.length <= 31 },
   'is ascii' => ->(s) { s.ascii_only? },
   'has non-digit first char' => ->(s) { !s[0].match(/\d/) },


### PR DESCRIPTION
- [x] remove requirement for VLAN id (and other required properties so stub resources can be used to manage system-provided units without mock data)
- [x] update platform versions for test suites
- [x] fix FC108 for binfmt, sysuser resources
- [x] remove nspawn workaround for older fedora version in test suite
- [x] add nspawn workaround for too-small debian machines.raw loopback volume in test suite