### PR TITLE
change resource sub-block evaluation context to avoid conflict with resource top-level properties

### DIFF
--- a/test/fixtures/cookbooks/test/recipes/units.rb
+++ b/test/fixtures/cookbooks/test/recipes/units.rb
@@ -38,6 +38,7 @@ systemd_service 'systemd-ask-password-console' do
     after %w( systemd-user-session.service )
   end
   service do
+    user 'root'
     exec_start_pre '-/usr/bin/systemctl stop systemd-ask-password-console.path systemd-ask-password-console.service systemd-ask-password-plymouth.path systemd-ask-password-plymouth.service'
     exec_start '/usr/bin/systemd-tty-ask-password-agent --wall'
   end

--- a/test/integration/default/units_spec.rb
+++ b/test/integration/default/units_spec.rb
@@ -44,6 +44,7 @@ control 'creates service units' do
 [Service]
 ExecStart = /usr/bin/systemd-tty-ask-password-agent --wall
 ExecStartPre = -/usr/bin/systemctl stop systemd-ask-password-console.path systemd-ask-password-console.service systemd-ask-password-plymouth.path systemd-ask-password-plymouth.service
+User = root
 
 [Unit]
 Description = forward password reqs to wall


### PR DESCRIPTION
this has been a pain point since the v3 rewrite (see #112, #125), but i wasn't ever sure how to get around it. thanks to some helpful advice from @coderanger tonight (👏), i was able to adapt the approach in the poise option_collector (switching the sub-resource block evaluation into a new context) and avoid this too-common and confusing error.

hip, hip, hooray!

now instead of:

```ruby
systemd_service 'my-app' do
  user 'bob'
  unit do
    description 'my super-cool app'
  end
  install do
    wanted_by 'multi-user.target'
  end
  service do
    service_user 'my-user'
    exec_start '/usr/bin/my-app'
  end
end
```

we can do:

```ruby
systemd_service 'my-app' do
  user 'bob'
  unit do
    description 'my super-cool app'
  end
  install do
    wanted_by 'multi-user.target'
  end
  service do
    user 'my-user'
    exec_start '/usr/bin/my-app'
  end
end
```