### PR TITLE
precursor compare_by_identy broken by string literal handling (fixes #133)

### DIFF
--- a/libraries/resource_factory.rb
+++ b/libraries/resource_factory.rb
@@ -117,7 +117,7 @@ module SystemdCookbook
                 rv.compare_by_identity
 
                 uc[rk].to_h.each_pair do |k, v|
-		  rv[k.dup] = v
+                  rv[k.dup] = v
                 end
 
                 uc[rk] = rv

--- a/libraries/resource_factory.rb
+++ b/libraries/resource_factory.rb
@@ -115,7 +115,12 @@ module SystemdCookbook
               uc = property_hash(data)
               r.precursor.each_pair do |rk, rv|
                 rv.compare_by_identity
-                uc[rk] = rv.merge(uc[rk].to_h)
+
+                uc[rk].to_h.each_pair do |k, v|
+		  rv[k.dup] = v
+                end
+
+                uc[rk] = rv
               end
 
               u = systemd_unit r.drop_in_name do

--- a/metadata.rb
+++ b/metadata.rb
@@ -5,9 +5,7 @@ license          'Apache-2.0'
 description      'chef cookbook for managing linux systems via systemd'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version          '3.2.2'
-chef_version     '>= 12.11' if respond_to?(:chef_version)
-
-depends          'compat_resource'
+chef_version     '>= 12.19' if respond_to?(:chef_version)
 
 supports         'arch'
 supports         'fedora'

--- a/test/fixtures/cookbooks/test/resources/file_toucher.rb
+++ b/test/fixtures/cookbooks/test/resources/file_toucher.rb
@@ -7,28 +7,28 @@ property :path, String, required: true
 default_action :create
 
 action :create do
-  systemd_service "file-toucher-#{name}" do
+  systemd_service "file-toucher-#{new_resource.name}" do
     service do
       type 'oneshot'
-      exec_start "/bin/touch #{path}"
+      exec_start "/bin/touch #{new_resource.path}"
     end
     action :create
   end
 
-  systemd_timer "file-toucher-#{name}" do
+  systemd_timer "file-toucher-#{new_resource.name}" do
     timer do
-      on_calendar time
+      on_calendar new_resource.time
     end
     action [:create, :enable, :start]
   end
 end
 
 action :delete do
-  systemd_service "file-toucher-#{name}" do
+  systemd_service "file-toucher-#{new_resource.name}" do
     action :delete
   end
 
-  systemd_timer "file-toucher-#{name}" do
+  systemd_timer "file-toucher-#{new_resource.name}" do
     action [:stop, :disable, :delete]
   end
 end

--- a/test/integration/default/daemons_spec.rb
+++ b/test/integration/default/daemons_spec.rb
@@ -36,7 +36,7 @@ EOT
 end
 
 control 'creates timesyncd drop-ins' do
-  if os[:fedora]
+  if os[:name] == 'fedora'
     describe file('/etc/systemd/timesyncd.conf.d/my-overrides.conf') do
       its(:content) do
         should eq <<EOT
@@ -46,7 +46,7 @@ FallbackNTP = 0.pool.ntp.org 1.pool.ntp.org 2.pool.ntp.org 3.pool.ntp.org
 EOT
       end
     end
-  elsif os[:debian]
+  elsif os[:name] == 'debian'
     describe file('/etc/systemd/timesyncd.conf.d/my-overrides.conf') do
       its(:content) do
         should eq <<EOT
@@ -56,7 +56,7 @@ FallbackNTP = 0.pool.ntp.org 1.pool.ntp.org 2.pool.ntp.org 3.pool.ntp.org
 EOT
       end
     end
-  elsif os[:ubuntu]
+  elsif os[:name] == 'ubuntu'
     describe file('/etc/systemd/timesyncd.conf.d/my-overrides.conf') do
       its(:content) do
         should eq <<EOT

--- a/test/integration/default/daemons_spec.rb
+++ b/test/integration/default/daemons_spec.rb
@@ -36,7 +36,8 @@ EOT
 end
 
 control 'creates timesyncd drop-ins' do
-  if os[:name] == 'fedora'
+  case os[:name]
+  when 'fedora'
     describe file('/etc/systemd/timesyncd.conf.d/my-overrides.conf') do
       its(:content) do
         should eq <<EOT
@@ -46,7 +47,7 @@ FallbackNTP = 0.pool.ntp.org 1.pool.ntp.org 2.pool.ntp.org 3.pool.ntp.org
 EOT
       end
     end
-  elsif os[:name] == 'debian'
+  when 'debian'
     describe file('/etc/systemd/timesyncd.conf.d/my-overrides.conf') do
       its(:content) do
         should eq <<EOT
@@ -56,7 +57,7 @@ FallbackNTP = 0.pool.ntp.org 1.pool.ntp.org 2.pool.ntp.org 3.pool.ntp.org
 EOT
       end
     end
-  elsif os[:name] == 'ubuntu'
+  when 'ubuntu'
     describe file('/etc/systemd/timesyncd.conf.d/my-overrides.conf') do
       its(:content) do
         should eq <<EOT

--- a/test/integration/default/drop_ins_spec.rb
+++ b/test/integration/default/drop_ins_spec.rb
@@ -44,7 +44,7 @@ EOT
 end
 
 control 'supports user drop-ins' do
-  if os[:fedora]
+  if os[:name] == 'fedora'
     describe file('/etc/systemd/user/dummy.service.d/user-service-drop-in.conf') do
       its(:content) do
         should eq <<EOT


### PR DESCRIPTION
- force dup string literals to make compare_by_identity work again
- fix tests' os checks for updated inspec syntax