### PR TITLE
WIP: support multiple addresses for network interfaces

### DIFF
--- a/libraries/data.rb
+++ b/libraries/data.rb
@@ -63,6 +63,9 @@ module SystemdCookbook
   ).freeze
 
   module Common
+    class ArrayToKeep < Array
+    end
+
     ABSOLUTE_PATH ||= {
       kind_of: String,
       callbacks: {
@@ -117,6 +120,9 @@ module SystemdCookbook
           Array(spec).all? { |p| Pathname.new(p).absolute? }
         end,
       },
+    }.freeze
+    ARRAY_OF_ADDRESSES ||= {
+      kind_of: [String, Array, ArrayToKeep],
     }.freeze
     ARRAY_OF_SOFT_ABSOLUTE_PATHS ||= {
       kind_of: [String, Array],
@@ -1456,7 +1462,7 @@ module SystemdCookbook
           ).concat([true, false]),
         },
         'BindCarrier' => Common::ARRAY,
-        'Address' => Common::STRING,
+        'Address' => Common::ARRAY_OF_ADDRESSES,
         'Gateway' => Common::STRING,
         'DNS' => Common::STRING,
         'Domains' => Common::ARRAY,

--- a/libraries/mixin.rb
+++ b/libraries/mixin.rb
@@ -80,7 +80,8 @@ module SystemdCookbook
               [
                 opt.camelcase,
                 option_value(
-                  send("#{section.underscore}_#{opt.underscore}".to_sym)
+                  send("#{section.underscore}_#{opt.underscore}".to_sym),
+                  "#{section.underscore}_#{opt.underscore}"
                 ),
               ]
             end.to_h
@@ -89,12 +90,22 @@ module SystemdCookbook
           result.delete_if { |_, v| v.empty? }
         end
 
-        def option_value(obj)
+        def option_value(obj, name=nil)
+          expected_types = self.class.properties[name.to_sym].validation_options[:kind_of]
+          if expected_types.kind_of?(Array) and expected_types.include?(SystemdCookbook::Common::ArrayToKeep)
+            keep_array=true
+          else
+            keep_array = false
+          end
           case obj
           when Hash
             obj.to_kv_pairs.join(' ')
           when Array
-            obj.join(' ')
+            if keep_array
+              obj
+            else
+              obj.join(' ')
+            end
           when TrueClass, FalseClass
             obj ? 'yes' : 'no'
           else


### PR DESCRIPTION
The idea is to use the ```kind_of``` attribute of a property to differentiate between
properties that need array values to be joined by " " and properties that need
to be written multiple times in the unit file

This patch is meant to be backwards compatible for other properties. 

However, a better approach would be to do it the other way around and to introduce a class JoinedArray and then to do the " " join in options_value only for those properties that include the JoinedArray in their ```kind_of``` attribute

If you like the idea, let me know and I will do it that way.