### PR TITLE
Update affected test files for upgraded chefdk versions

### DIFF
--- a/libraries/data.rb
+++ b/libraries/data.rb
@@ -138,7 +138,7 @@ module SystemdCookbook
       kind_of: [String, Array],
       callbacks: {
         'contains only valid URIs' => lambda do |spec|
-          Array(spec).all? { |u| u =~ /\A#{URI.regexp}\z/ }
+          Array(spec).all? { |u| u =~ /\A#{URI::DEFAULT_PARSER.make_regexp}\z/ }
         end,
       },
     }.freeze

--- a/libraries/resource_factory.rb
+++ b/libraries/resource_factory.rb
@@ -66,8 +66,6 @@ module SystemdCookbook
             end
           end
         end
-        # rubocop: enable AbcSize
-        # rubocop: enable MethodLength
       end
     end
 
@@ -150,8 +148,6 @@ module SystemdCookbook
             end
           end
         end
-        # rubocop: enable MethodLength
-        # rubocop: enable AbcSize
       end
     end
 
@@ -196,8 +192,6 @@ module SystemdCookbook
             end
           end
         end
-        # rubocop: enable MethodLength
-        # rubocop: enable AbcSize
       end
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -7,5 +7,3 @@ RSpec.configure do |config|
   config.platform = 'centos'
   config.version = '7.3.1611'
 end
-
-ChefSpec::Coverage.start!


### PR DESCRIPTION
Just updating the respective tests to adhere to the recommendations in the latest version of chefdk. Versions I ran this against:
```
Chef Development Kit Version: 3.1.0
chef-client version: 14.2.0
delivery version: master (6862f27aba89109a9630f0b6c6798efec56b4efe)
berks version: 7.0.4
kitchen version: 1.22.0
inspec version: 2.1.72
Cookstyle 3.0.0
  * RuboCop 0.55.0
```