### PR TITLE
Fix integration tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,11 +12,11 @@ install: echo "skip bundle install"
 
 before_script:
   - eval "$(chef shell-init bash)"
-
-script:
   - chef --version
   - chef exec cookstyle --version
-  - chef exec cookstyle
   - chef exec foodcritic --version
+
+script:
+  - chef exec cookstyle
   - chef exec foodcritic . --exclude spec -f any -P
   - chef exec rspec

--- a/test/fixtures/cookbooks/test/recipes/misc.rb
+++ b/test/fixtures/cookbooks/test/recipes/misc.rb
@@ -75,29 +75,29 @@ execute 'mkfs.btrfs /var/lib/machines.raw' do
   notifies :start, 'systemd_mount[var-lib-machines]', :immediately
 end
 
-systemd_machine_image 'Fedora26' do
+systemd_machine_image 'Fedora27' do
   type 'raw'
-  source 'https://dl.fedoraproject.org/pub/fedora/linux/releases/26/CloudImages/x86_64/images/Fedora-Cloud-Base-26-1.5.x86_64.raw.xz'
+  source 'https://dl.fedoraproject.org/pub/fedora/linux/releases/27/CloudImages/x86_64/images/Fedora-Cloud-Base-27-1.6.x86_64.raw.xz'
   verify 'no'
   read_only false
   format 'gzip'
-  path '/var/tmp/Fedora26.raw.gz'
+  path '/var/tmp/Fedora27.raw.gz'
   to 'cloned'
   action [:pull, :set_properties, :export, :clone]
   not_if { platform?('centos') }
 end
 
-systemd_machine_image 'Fedora26b' do
+systemd_machine_image 'Fedora27b' do
   type 'raw'
   verify 'no'
   read_only true
   format 'gzip'
-  path '/var/tmp/Fedora26.raw.gz'
+  path '/var/tmp/Fedora27.raw.gz'
   action [:import, :set_properties]
   not_if { platform?('centos') }
 end
 
-systemd_nspawn 'Fedora26' do
+systemd_nspawn 'Fedora27' do
   exec do
     boot true
     private_users false
@@ -113,11 +113,11 @@ end
 
 require 'tempfile'
 
-tmp = Tempfile.new('Fedora26')
+tmp = Tempfile.new('Fedora27')
 tmp_path = tmp.path
 tmp.delete
 
-systemd_machine 'Fedora26' do
+systemd_machine 'Fedora27' do
   host_path tmp_path
   machine_path '/etc/passwd'
   action [:enable, :start, :copy_from]

--- a/test/integration/default/misc_spec.rb
+++ b/test/integration/default/misc_spec.rb
@@ -105,7 +105,7 @@ control 'creates tmpfiles' do
 end
 
 control 'creates nspawn units' do
-  describe file('/etc/systemd/nspawn/Fedora26.nspawn') do
+  describe file('/etc/systemd/nspawn/Fedora27.nspawn') do
     its(:content) do
       should eq <<EOT
 [Exec]
@@ -126,8 +126,8 @@ end
 control 'machine image' do
   unless os.redhat?
     describe command('machinectl list-images') do
-      its(:stdout) { should match /Fedora26  raw  no/ }
-      its(:stdout) { should match /Fedora26b raw  yes/ }
+      its(:stdout) { should match /Fedora27  raw  no/ }
+      its(:stdout) { should match /Fedora27b raw  yes/ }
       its(:stdout) { should match /cloned    raw  no/ }
     end
   end
@@ -136,7 +136,7 @@ end
 control 'machine' do
   unless os.redhat?
     describe command('machinectl list') do
-      its(:stdout) { should match /Fedora26 container systemd-nspawn/ }
+      its(:stdout) { should match /Fedora27 container systemd-nspawn/ }
     end
   end
 end


### PR DESCRIPTION
The versioned image you depend on for integration tests was archived and an updated image was published. This results in all suites passing their integration tests:
```
default-centos-74    Vagrant  ChefZero     Inspec    Ssh        Verified     <None>
default-fedora-27    Vagrant  ChefZero     Inspec    Ssh        Verified     <None>
default-debian-93    Vagrant  ChefZero     Inspec    Ssh        Verified     <None>
default-ubuntu-1604  Vagrant  ChefZero     Inspec    Ssh        Verified     <None>
```