### PR TITLE
Fix keyword arguments call (Ruby 3 / Chef 17 breakage)

### DIFF
--- a/libraries/mixin.rb
+++ b/libraries/mixin.rb
@@ -61,7 +61,7 @@ module SystemdCookbook
           options.each_pair do |section, opts|
             opts.each_pair do |opt, conf|
               property "#{section.underscore}_#{opt.underscore}".to_sym,
-                       conf.merge(desired_state: false)
+                       **conf.merge(desired_state: false)
             end
           end
         end


### PR DESCRIPTION
Starting with Ruby 3.0, you can no longer pass a hash as the last argument for named arguments.

Fixes #146
Fixes #144

Tested with the latest Chef version.