### PR TITLE
Pin rexml and bump cookbook version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 3.2.6 / 2024-05-17
+
+* pin rexml as a result of https://github.com/ruby/rexml/issues/131
+
 # 3.2.5 / 2021-05-07
 
 * fix keyword arguments in chef 17

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'nath.e.will@gmail.com'
 license          'Apache-2.0'
 description      'chef cookbook for managing linux systems via systemd'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '3.2.5'
+version          '3.2.6'
 chef_version     '>= 12.19' if respond_to?(:chef_version)
 
 supports         'arch'
@@ -15,6 +15,7 @@ supports         'ubuntu', '>= 15.04'
   supports         p, '>= 7.0'
 end
 
+gem              'rexml', '<= 3.2.6' if respond_to?(:gem)
 gem              'dbus-systemd', '~> 1.1' if respond_to?(:gem)
 
 source_url       'https://github.com/nathwill/chef-systemd' if respond_to?(:source_url)


### PR DESCRIPTION
Rexml is a dependancy for dbus-systemd which is installed by this cookbook. Rexml introduced new versions which now require strscan as a runtime dependency. To instantall strscan we need build tools on nodes such as make, gcc which is something we rather avoid having everywhere. 

details: https://github.com/ruby/rexml/issues/131